### PR TITLE
chore: update build:test script to clean dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "npm test",
-    "build:test": "tsc && tsc -p test",
+    "build:test": "rm -rf **/dist && tsc && tsc -p test",
     "test": "npm run build:test && node --experimental-test-coverage --test \"**/*.test.js\""
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "npm test",
-    "build:test": "rm -rf **/dist && tsc && tsc -p test",
+    "build:test": "rimraf dist test/dist && tsc && tsc -p test",
     "test": "npm run build:test && node --experimental-test-coverage --test \"**/*.test.js\""
   },
   "keywords": [
@@ -40,7 +40,8 @@
     "@types/n3": "^1",
     "n3": "^2",
     "typedoc": "^0.28.18",
-    "typedoc-plugin-mdn-links": "^5.1.1"
+    "typedoc-plugin-mdn-links": "^5.1.1",
+    "rimraf": "^6.0.1"
   },
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
When a typescript file is deleted, its artefacts remain in the test folder after running `tsc` as there is no build artefact to override them.