### PR TITLE
fix: NamedGraphError reports the offending graph IRI

### DIFF
--- a/src/errors/NamedGraphError.ts
+++ b/src/errors/NamedGraphError.ts
@@ -8,6 +8,6 @@ import type { Quad } from "@rdfjs/types"
  */
 export class NamedGraphError extends QuadError {
     constructor(quad: Quad, cause?: any) {
-        super(quad, `Graph must be default (empty) but was ${quad.value}`, cause)
+        super(quad, `Graph must be default (empty) but was ${quad.graph.value}`, cause)
     }
 }

--- a/test/unit/named_graph.test.ts
+++ b/test/unit/named_graph.test.ts
@@ -117,6 +117,16 @@ await describe("namedGraph", async () => {
         )
     })
 
+    await it("NamedGraphError message reports the offending graph IRI", () => {
+        const ds = new SomeDataset(storeWithNamedGraph(), DataFactory).namedGraph
+        const offendingGraph = DataFactory.namedNode("https://other.org/g")
+
+        assert.throws(
+            () => ds.add(DataFactory.quad(s, p, o, offendingGraph)),
+            (error: unknown) => error instanceof NamedGraphError && error.message.includes(offendingGraph.value),
+        )
+    })
+
     await it("throws TermTypeError when matching with a non-default graph", () => {
         const ds = new SomeDataset(storeWithNamedGraph(), DataFactory).namedGraph
 


### PR DESCRIPTION
### What this does

`NamedGraphError`'s message interpolated `quad.value`, which is always the empty string for an RDF/JS Quad, so the error read:

```
Graph must be default (empty) but was
```

and never told you *which* graph caused the failure. This changes the interpolation to `quad.graph.value` so the message reports the offending graph IRI, and adds a regression test in `test/unit/named_graph.test.ts` asserting the thrown message contains that IRI.

No API change: the constructor signature and error hierarchy are untouched.

### Related issues / PRs

- Addresses the defensive/robust-code theme of #6 (errors should carry actionable diagnostics).
- Supersedes exactly one slice of the omnibus draft #73: the `NamedGraphError` message fix (`quad.value` -> `quad.graph.value`). The accompanying `Quad` -> `BaseQuad` signature change in #73 belongs to the scoped-dataset refactor and is deliberately **not** included here.

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday-Friday (8-10 July).
