### PR TITLE
feat: DatasetWrapper helpers return T & Quad_Subject / T & Quad_Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const dataset_x = new N3.Store(new N3.Parser().parse(rdf)) // rdf holds the turt
 Class usage:
 
 ```javascript
-const person1 = new Person("https://example.org/person1", dataset_x, DataFactory)
+const person1 = Person.from("https://example.org/person1", dataset_x, DataFactory)
 
 // Get property
 console.log(person1.name)
@@ -154,7 +154,7 @@ ex:person2
 Class usage:
 
 ```javascript
-const person2 = new Person("https://example.org/person2", dataset_z, DataFactory)
+const person2 = Person.from("https://example.org/person2", dataset_z, DataFactory)
 
 // Get property
 console.log(person2.name)
@@ -165,7 +165,7 @@ console.log(person2.mum.name)
 // outputs "Alice"
 
 // Set class properties
-const person3 = new Person("https://example.org/person3", dataset_z, DataFactory)
+const person3 = Person.from("https://example.org/person3", dataset_z, DataFactory)
 person3.name = "Joanne"
 person1.mum = person3
 console.log(person1.mum.name)

--- a/src/DatasetWrapper.ts
+++ b/src/DatasetWrapper.ts
@@ -1,7 +1,8 @@
-import type { DataFactory, DatasetCore, Quad, Quad_Graph, Term } from "@rdfjs/types"
+import type { DataFactory, DatasetCore, Quad, Quad_Graph, Quad_Object, Quad_Subject, Term } from "@rdfjs/types"
 import type { ITermWrapperConstructor } from "./type/ITermWrapperConstructor.js"
 import type { NamedGraphDataset } from "./NamedGraphDataset.js"
 import type { INamedGraphDatasetConstructor } from "./type/INamedGraphDatasetConstructor.js"
+import type { TermWrapper } from "./TermWrapper.js"
 
 import { RDF } from "./vocabulary/RDF.js"
 
@@ -41,15 +42,45 @@ export class DatasetWrapper implements DatasetCore {
 
     //#region Utilities
 
-    protected subjectsOf<T>(predicate: string, termWrapper: ITermWrapperConstructor<T>): Iterable<T> {
+    /**
+     * Yields a wrapper around the subject of every statement with the given predicate.
+     *
+     * @remarks
+     * The results are typed as both the wrapper and the {@link Quad.subject | subject term} they wrap, so they can be passed directly anywhere an RDF/JS {@link Term} is expected — for example when creating quads with a {@link DataFactory} or when matching with {@link DatasetCore.match} — without casts.
+     *
+     * @param predicate - The IRI of the predicate to match.
+     * @param termWrapper - A constructor of a class derived from {@link TermWrapper} that wraps each result.
+     * @returns Wrappers around the subjects of matching statements, typed additionally as the subject terms they wrap.
+     */
+    protected subjectsOf<T extends TermWrapper>(predicate: string, termWrapper: ITermWrapperConstructor<T>): Iterable<T & Quad_Subject> {
         return this.matchSubjectsOf(termWrapper, this.factory.namedNode(predicate))
     }
 
-    protected objectsOf<T>(predicate: string, termWrapper: ITermWrapperConstructor<T>): Iterable<T> {
+    /**
+     * Yields a wrapper around the object of every statement with the given predicate.
+     *
+     * @remarks
+     * The results are typed as both the wrapper and the {@link Quad.object | object term} they wrap, so they can be passed directly anywhere an RDF/JS {@link Term} is expected — for example when creating quads with a {@link DataFactory} or when matching with {@link DatasetCore.match} — without casts.
+     *
+     * @param predicate - The IRI of the predicate to match.
+     * @param termWrapper - A constructor of a class derived from {@link TermWrapper} that wraps each result.
+     * @returns Wrappers around the objects of matching statements, typed additionally as the object terms they wrap.
+     */
+    protected objectsOf<T extends TermWrapper>(predicate: string, termWrapper: ITermWrapperConstructor<T>): Iterable<T & Quad_Object> {
         return this.matchObjectsOf(termWrapper, undefined, this.factory.namedNode(predicate))
     }
 
-    protected instancesOf<T>(klass: string, constructor: ITermWrapperConstructor<T>): Iterable<T> {
+    /**
+     * Yields a wrapper around every instance of the given class, that is the subject of every statement with a predicate of `rdf:type` and the given class as the object.
+     *
+     * @remarks
+     * The results are typed as both the wrapper and the {@link Quad.subject | subject term} they wrap, so they can be passed directly anywhere an RDF/JS {@link Term} is expected — for example when creating quads with a {@link DataFactory} or when matching with {@link DatasetCore.match} — without casts.
+     *
+     * @param klass - The IRI of the class to match instances of.
+     * @param constructor - A constructor of a class derived from {@link TermWrapper} that wraps each result.
+     * @returns Wrappers around the instances, typed additionally as the subject terms they wrap.
+     */
+    protected instancesOf<T extends TermWrapper>(klass: string, constructor: ITermWrapperConstructor<T>): Iterable<T & Quad_Subject> {
         return this.matchSubjectsOf(constructor, this.factory.namedNode(RDF.type), this.factory.namedNode(klass))
     }
 
@@ -69,15 +100,39 @@ export class DatasetWrapper implements DatasetCore {
         return new klass(g, this.dataset, this.factory)
     }
 
-    protected* matchSubjectsOf<T>(termWrapper: ITermWrapperConstructor<T>, predicate?: Term, object?: Term, graph?: Term): Iterable<T> {
+    /**
+     * Yields a wrapper around the subject of every statement matching the given pattern.
+     *
+     * @remarks
+     * The results are typed as both the wrapper and the {@link Quad.subject | subject term} they wrap, so they can be passed directly anywhere an RDF/JS {@link Term} is expected — for example when creating quads with a {@link DataFactory} or when matching with {@link DatasetCore.match} — without casts.
+     *
+     * @param termWrapper - A constructor of a class derived from {@link TermWrapper} that wraps each result.
+     * @param predicate - The predicate to match, if any.
+     * @param object - The object to match, if any.
+     * @param graph - The graph to match, if any.
+     * @returns Wrappers around the subjects of matching statements, typed additionally as the subject terms they wrap.
+     */
+    protected* matchSubjectsOf<T extends TermWrapper>(termWrapper: ITermWrapperConstructor<T>, predicate?: Term, object?: Term, graph?: Term): Iterable<T & Quad_Subject> {
         for (const q of this.match(undefined, predicate, object, graph)) {
-            yield new termWrapper(q.subject, this, this.factory)
+            yield termWrapper.from(q.subject, this, this.factory)
         }
     }
 
-    protected* matchObjectsOf<T>(termWrapper: ITermWrapperConstructor<T>, subject?: Term, predicate?: Term, graph?: Term): Iterable<T> {
+    /**
+     * Yields a wrapper around the object of every statement matching the given pattern.
+     *
+     * @remarks
+     * The results are typed as both the wrapper and the {@link Quad.object | object term} they wrap, so they can be passed directly anywhere an RDF/JS {@link Term} is expected — for example when creating quads with a {@link DataFactory} or when matching with {@link DatasetCore.match} — without casts.
+     *
+     * @param termWrapper - A constructor of a class derived from {@link TermWrapper} that wraps each result.
+     * @param subject - The subject to match, if any.
+     * @param predicate - The predicate to match, if any.
+     * @param graph - The graph to match, if any.
+     * @returns Wrappers around the objects of matching statements, typed additionally as the object terms they wrap.
+     */
+    protected* matchObjectsOf<T extends TermWrapper>(termWrapper: ITermWrapperConstructor<T>, subject?: Term, predicate?: Term, graph?: Term): Iterable<T & Quad_Object> {
         for (const q of this.match(subject, predicate, undefined, graph)) {
-            yield new termWrapper(q.object, this, this.factory)
+            yield termWrapper.from(q.object, this, this.factory)
         }
     }
 

--- a/src/TermWrapper.ts
+++ b/src/TermWrapper.ts
@@ -98,6 +98,111 @@ export class TermWrapper implements IRdfJsTerm {
         this._factory = factory
     }
 
+    //#region Static factory
+
+    /**
+     * Creates a new instance of this class (or subclass) from an IRI, typed as both the wrapper and the {@link NamedNode} it wraps.
+     *
+     * @remarks
+     * This factory is equivalent to invoking the constructor directly, differing only in the return type: the constructor returns the declared instance type, whereas this factory returns the intersection of the (sub)class instance type and {@link NamedNode}. Because the result _is_ a {@link NamedNode} at the type level, it can be passed directly anywhere an RDF/JS {@link Term} is expected — for example when creating quads with a {@link DataFactory} or when matching with {@link DatasetCore.match} — without casts.
+     *
+     * @example Creating an instance of a subclass
+     * Assume the following RDF data:
+     * ```turtle
+     * BASE <http://example.com/>
+     *
+     * <someSubject> <someProperty> "some value" .
+     * ```
+     * We can wrap the subject and use the wrapper directly as a named node:
+     * ```ts
+     * class SomeClass extends TermWrapper {
+     *   get someProperty(): string {
+     *     return RequiredFrom.subjectPredicate(this, "http://example.com/someProperty", LiteralAs.string)
+     *   }
+     * }
+     *
+     * const instance = SomeClass.from("http://example.com/someSubject", dataset, factory)
+     * // instance is typed as SomeClass & NamedNode
+     *
+     * const value = instance.someProperty // contains "some value"
+     * ```
+     *
+     * @example Using created instances directly as RDF/JS terms
+     * In contrast to instances created with the constructor, no casts are required to use the result as a term:
+     * ```ts
+     * const instance = SomeClass.from("http://example.com/someSubject", dataset, factory)
+     *
+     * // Used as subject when creating a quad
+     * factory.quad(instance, predicate, object)
+     *
+     * // Used as subject when matching statements in a dataset
+     * dataset.match(instance)
+     * ```
+     *
+     * @param term The IRI of a named node that is the original term being wrapped.
+     * @param dataset The dataset that contains the term being wrapped.
+     * @param factory A collection of methods for creating terms.
+     * @returns A new instance of the class this method was invoked on, typed additionally as the {@link NamedNode} it wraps.
+     *
+     * @see
+     * - [Named nodes in the RDF/JS Data model specification](https://rdf.js.org/data-model-spec/#namednode-interface)
+     */
+    public static from<This extends new (term: string, dataset: DatasetCore, factory: DataFactory) => any>(
+        this: This,
+        term: string,
+        dataset: DatasetCore,
+        factory: DataFactory,
+    ): InstanceType<This> & NamedNode<string>
+
+    /**
+     * Creates a new instance of this class (or subclass), typed as both the wrapper and the type of the {@link Term} it wraps.
+     *
+     * @remarks
+     * This factory is equivalent to invoking the constructor directly, differing only in the return type: the constructor returns the declared instance type, whereas this factory returns the intersection of the (sub)class instance type and the type of the `term` argument. Because the result _is_ a {@link Term} at the type level, it can be passed directly anywhere an RDF/JS term is expected — for example when creating quads with a {@link DataFactory} or when matching with {@link DatasetCore.match} — without casts.
+     *
+     * @example Wrapping a literal
+     * The term type of the argument is preserved in the return type, so term-type-specific members are available without casts:
+     * ```ts
+     * const literal = factory.literal("some value", "en")
+     * const instance = SomeClass.from(literal, dataset, factory)
+     * // instance is typed as SomeClass & Literal
+     *
+     * const language = instance.language // contains "en"
+     * ```
+     *
+     * @example Using created instances directly as RDF/JS terms
+     * In contrast to instances created with the constructor, no casts are required to use the result as a term:
+     * ```ts
+     * const instance = SomeClass.from(factory.blankNode(), dataset, factory)
+     *
+     * // Used as subject when creating a quad
+     * factory.quad(instance, predicate, object)
+     *
+     * // Used as subject when matching statements in a dataset
+     * dataset.match(instance)
+     * ```
+     *
+     * @param term The original term being wrapped.
+     * @param dataset The dataset that contains the term being wrapped.
+     * @param factory A collection of methods for creating terms.
+     * @returns A new instance of the class this method was invoked on, typed additionally as the {@link Term} it wraps.
+     *
+     * @see
+     * - [Terms in the RDF/JS Data model specification](https://rdf.js.org/data-model-spec/#term-interface)
+     */
+    public static from<T extends Term, This extends new (term: T, dataset: DatasetCore, factory: DataFactory) => any>(
+        this: This,
+        term: T,
+        dataset: DatasetCore,
+        factory: DataFactory,
+    ): InstanceType<This> & T
+
+    public static from(this: any, term: string | Term, dataset: DatasetCore, factory: DataFactory): any {
+        return new this(term, dataset, factory)
+    }
+
+    //#endregion
+
     /**
      * The dataset that contains this term.
      *

--- a/src/mapping/TermAs.ts
+++ b/src/mapping/TermAs.ts
@@ -14,7 +14,7 @@ import { ensureIs, ensureListRoot, ensurePresent } from "../ensure.js"
  * - [Nodes in RDF 1.1 Concepts and Abstract Syntax](https://www.w3.org/TR/rdf11-concepts/#dfn-node)
  */
 export namespace TermAs {
-    export function instance<T>(constructor: ITermWrapperConstructor<T>): ITermAsValueMapping<T> {
+    export function instance<T extends TermWrapper>(constructor: ITermWrapperConstructor<T>): ITermAsValueMapping<T> {
         return (term: TermWrapper) => {
             ensurePresent(term)
             ensureIs(term, TermWrapper)

--- a/src/type/ITermWrapperConstructor.ts
+++ b/src/type/ITermWrapperConstructor.ts
@@ -1,18 +1,21 @@
 import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
+import type { TermWrapper } from "../TermWrapper.js"
 
 /**
- * Represents the constructor signature of term mapping classes that extend {@link TermWrapper}.
+ * Represents the static side of term mapping classes that extend {@link TermWrapper}: a constructor signature combined with the {@link TermWrapper.from | from static factory}.
  *
  * Used by this library where constructors of mappers are accepted for implementing navigation properties that represent graph patterns on dataset and term wrappers.
  *
- * @template T - The type of the mapping class whose instance is created.
+ * @template T - The type of the mapping class whose instance is created. Must derive from {@link TermWrapper}, which is also the default.
  * @param term - The underlying term being wrapped.
  * @param dataset - The dataset containing the wrapped term.
  * @param factory - The data factory used for creating new terms.
  * @returns An instance of the mapping class created when invoking the constructor.
  *
  * @remarks
- * Mapping classes do not need to define a constructor that matches this signature, because the base class has a publicly accessible, matching {@link TermWrapper.constructor | constructor}.
+ * Mapping classes do not need to define a constructor that matches this signature, because the base class has a publicly accessible, matching {@link TermWrapper.constructor | constructor}. Likewise, they do not need to define the {@link TermWrapper.from | from static factory}, because every class derived from {@link TermWrapper} inherits it automatically.
+ *
+ * The library invokes {@link TermWrapper.from} rather than the constructor where it can improve the created instance's type with the type of the term it wraps, for example in {@link DatasetWrapper.matchSubjectsOf} and {@link DatasetWrapper.matchObjectsOf}.
  *
  * @example Projecting from a dataset to a mapping class
  * Given the mapping
@@ -88,5 +91,8 @@ import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
  * - {@link DatasetWrapper.matchSubjectsOf}
  * - {@link DatasetWrapper.objectsOf}
  * - {@link TermAs.instance}
+ * - {@link TermWrapper.from}
  */
-export type ITermWrapperConstructor<T> = new (term: Term, dataset: DatasetCore, factory: DataFactory) => T
+export type ITermWrapperConstructor<T extends TermWrapper = TermWrapper> =
+    (new (term: Term, dataset: DatasetCore, factory: DataFactory) => T) &
+    Pick<typeof TermWrapper, "from">

--- a/test/unit/dataset_wrapper_types.test.ts
+++ b/test/unit/dataset_wrapper_types.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert"
+import { describe, it } from "node:test"
+import { DataFactory } from "n3"
+import type { DataFactory as IDataFactory, DatasetCore, Literal, Quad_Object, Quad_Predicate, Quad_Subject, Term } from "@rdfjs/types"
+import type { ITermWrapperConstructor } from "@rdfjs/wrapper"
+import { ParentDataset } from "./model/ParentDataset.js"
+import { Parent } from "./model/Parent.js"
+import { Child } from "./model/Child.js"
+import { datasetFromRdf } from "./util/datasetFromRdf.js"
+
+const rdf = `
+prefix : <https://example.org/>
+
+<x>
+    a :Parent ;
+    :hasString "o1" ;
+    :hasChild [
+        :hasString "child string 1" ;
+    ] ;
+.
+<y>
+    :hasString "o2" ;
+    :hasChild <z> ;
+.
+<z>
+    :hasString "child string 4" ;
+.
+`
+
+await describe("Dataset wrapper types", async () => {
+    const parentDataset = new ParentDataset(datasetFromRdf(rdf), DataFactory)
+
+    await describe("instancesOf", async () => {
+        const parents = [...parentDataset.instancesOfParent]
+
+        await it("yields wrappers exposing the members of the mapping class", () => {
+            assert.equal(parents.length, 1)
+
+            for (const parent of parents) {
+                assert.equal(typeof parent.hasString, "string")
+                assert.equal(typeof parent.termType, "string")
+                assert.equal(typeof parent.value, "string")
+                assert.equal(typeof parent.equals, "function")
+            }
+        })
+
+        await it("yields wrappers usable as subject terms without casts", () => {
+            for (const parent of parents) {
+                const subject: Quad_Subject = parent
+                const quad = DataFactory.quad(parent, DataFactory.namedNode("p"), DataFactory.literal("o"))
+
+                assert.equal(subject.equals(parent), true)
+                assert.equal(quad.subject.equals(parent), true)
+                assert.equal(parentDataset.match(parent).size, 3)
+            }
+        })
+
+        await it("yields wrappers that are not literal or predicate terms", () => {
+            for (const parent of parents) {
+                // @ts-expect-error a matched subject is never a literal
+                const literal: Literal = parent
+                // @ts-expect-error a matched subject may be a blank node, which is not a valid predicate
+                const predicate: Quad_Predicate = parent
+
+                void literal
+                void predicate
+            }
+        })
+    })
+
+    await describe("subjectsOf", async () => {
+        const parents = [...parentDataset.subjectsOfHasChild]
+
+        await it("yields wrappers exposing the members of the mapping class", () => {
+            assert.equal(parents.length, 2)
+
+            for (const parent of parents) {
+                assert.equal(typeof parent.hasString, "string")
+                assert.equal(typeof parent.termType, "string")
+            }
+        })
+
+        await it("yields wrappers usable as subject terms without casts", () => {
+            for (const parent of parents) {
+                const subject: Quad_Subject = parent
+
+                assert.equal(subject.equals(parent), true)
+            }
+        })
+
+        await it("yields wrappers that are not literal or predicate terms", () => {
+            for (const parent of parents) {
+                // @ts-expect-error a matched subject is never a literal
+                const literal: Literal = parent
+                // @ts-expect-error a matched subject may be a blank node, which is not a valid predicate
+                const predicate: Quad_Predicate = parent
+
+                void literal
+                void predicate
+            }
+        })
+    })
+
+    await describe("objectsOf", async () => {
+        const children = [...parentDataset.objectsOfHasChild]
+
+        await it("yields wrappers exposing the members of the mapping class", () => {
+            assert.equal(children.length, 2)
+
+            for (const child of children) {
+                assert.equal(typeof child.hasString, "string")
+                assert.equal(typeof child.termType, "string")
+                assert.equal(typeof child.value, "string")
+            }
+        })
+
+        await it("yields wrappers usable as object terms without casts", () => {
+            for (const child of children) {
+                const object: Quad_Object = child
+                const quad = DataFactory.quad(DataFactory.namedNode("s"), DataFactory.namedNode("p"), child)
+
+                assert.equal(object.equals(child), true)
+                assert.equal(quad.object.equals(child), true)
+                assert.equal(parentDataset.match(undefined, undefined, child).size, 1)
+            }
+        })
+
+        await it("yields wrappers that are not subject or predicate terms", () => {
+            for (const child of children) {
+                // @ts-expect-error a matched object may be a literal, which is not a valid subject
+                const subject: Quad_Subject = child
+                // @ts-expect-error a matched object may be a literal, which is not a valid predicate
+                const predicate: Quad_Predicate = child
+
+                void subject
+                void predicate
+            }
+        })
+    })
+
+    await describe("matchSubjectsOf", async () => {
+        const parents = [...parentDataset.matchSubjectsOfPropertyanyObjectparentGraphany]
+
+        await it("yields wrappers exposing the members of the mapping class", () => {
+            assert.equal(parents.length, 1)
+
+            for (const parent of parents) {
+                assert.equal(typeof parent.hasString, "string")
+                assert.equal(typeof parent.termType, "string")
+            }
+        })
+
+        await it("yields wrappers usable as subject terms without casts", () => {
+            for (const parent of parents) {
+                const subject: Quad_Subject = parent
+
+                assert.equal(subject.equals(parent), true)
+            }
+        })
+
+        await it("yields wrappers that are not literal terms", () => {
+            for (const parent of parents) {
+                // @ts-expect-error a matched subject is never a literal
+                const literal: Literal = parent
+
+                void literal
+            }
+        })
+    })
+
+    await describe("matchObjectsOf", async () => {
+        const children = [...parentDataset.matchObjectsOfSubjectxPropertyhaschildGraphany]
+
+        await it("yields wrappers exposing the members of the mapping class", () => {
+            assert.equal(children.length, 1)
+
+            for (const child of children) {
+                assert.equal(typeof child.hasString, "string")
+                assert.equal(typeof child.value, "string")
+            }
+        })
+
+        await it("yields wrappers usable as object terms without casts", () => {
+            for (const child of children) {
+                const object: Quad_Object = child
+
+                assert.equal(object.equals(child), true)
+            }
+        })
+
+        await it("yields wrappers that are not subject terms", () => {
+            for (const child of children) {
+                // @ts-expect-error a matched object may be a literal, which is not a valid subject
+                const subject: Quad_Subject = child
+
+                void subject
+            }
+        })
+    })
+
+    await describe("ITermWrapperConstructor", async () => {
+        await it("is satisfied automatically by classes derived from TermWrapper", () => {
+            const parentConstructor: ITermWrapperConstructor<Parent> = Parent
+            const childConstructor: ITermWrapperConstructor<Child> = Child
+
+            assert.equal(parentConstructor, Parent)
+            assert.equal(childConstructor, Child)
+        })
+
+        await it("rejects classes that do not derive from TermWrapper", () => {
+            class PlainTermClass {
+                public constructor(term: Term, dataset: DatasetCore, factory: IDataFactory) {
+                    void term
+                    void dataset
+                    void factory
+                }
+            }
+
+            // @ts-expect-error PlainTermClass does not derive from TermWrapper, so it lacks the from static factory
+            const plainConstructor: ITermWrapperConstructor = PlainTermClass
+
+            assert.equal(typeof plainConstructor, "function")
+        })
+    })
+})

--- a/test/unit/model/ParentDataset.ts
+++ b/test/unit/model/ParentDataset.ts
@@ -1,26 +1,27 @@
+import type { Quad_Object, Quad_Subject } from "@rdfjs/types"
 import { DatasetWrapper } from "@rdfjs/wrapper"
 import { Parent } from "./Parent.js"
 import { Child } from "./Child.js"
 import { Example } from "../vocabulary/Example.js"
 
 export class ParentDataset extends DatasetWrapper {
-    public get instancesOfParent(): Iterable<Parent> {
+    public get instancesOfParent(): Iterable<Parent & Quad_Subject> {
         return this.instancesOf(Example.Parent, Parent)
     }
 
-    public get subjectsOfHasChild(): Iterable<Parent> {
+    public get subjectsOfHasChild(): Iterable<Parent & Quad_Subject> {
         return this.subjectsOf(Example.hasChild, Parent)
     }
 
-    public get objectsOfHasChild(): Iterable<Child> {
+    public get objectsOfHasChild(): Iterable<Child & Quad_Object> {
         return this.objectsOf(Example.hasChild, Child)
     }
 
-    public get matchSubjectsOfPropertyanyObjectparentGraphany(): Iterable<Parent> {
+    public get matchSubjectsOfPropertyanyObjectparentGraphany(): Iterable<Parent & Quad_Subject> {
         return this.matchSubjectsOf(Parent, undefined, this.factory.namedNode(Example.Parent), undefined)
     }
 
-    public get matchObjectsOfSubjectxPropertyhaschildGraphany(): Iterable<Child> {
+    public get matchObjectsOfSubjectxPropertyhaschildGraphany(): Iterable<Child & Quad_Object> {
         return this.matchObjectsOf(Child, this.factory.namedNode("x"), this.factory.namedNode(Example.hasChild), undefined)
     }
 }

--- a/test/unit/term_wrapper_from.test.ts
+++ b/test/unit/term_wrapper_from.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert"
+import { describe, it } from "node:test"
+import { DataFactory } from "n3"
+import { TermWrapper } from "@rdfjs/wrapper"
+import { Child } from "./model/Child.js"
+import { datasetFromRdf } from "./util/datasetFromRdf.js"
+import { Example } from "./vocabulary/Example.js"
+import type { NamedNode, Quad_Subject, Term } from "@rdfjs/types"
+
+const rdf = `
+prefix : <https://example.org/>
+
+<x> :hasString "string 1" .
+`
+
+await describe("Term Wrapper from", async () => {
+    const dataset = datasetFromRdf(rdf)
+
+    await describe("Runtime behaviour", async () => {
+        await it("creates an instance of the subclass it is invoked on", async () => {
+            const child = Child.from("x", dataset, DataFactory)
+
+            assert.equal(child instanceof Child, true)
+            assert.equal(child instanceof TermWrapper, true)
+        })
+
+        await it("creates an instance of the base class when invoked on it", async () => {
+            const wrapper = TermWrapper.from("x", dataset, DataFactory)
+
+            assert.equal(wrapper instanceof TermWrapper, true)
+        })
+
+        await it("wraps a string as a named node, like the constructor", async () => {
+            const child = Child.from("x", dataset, DataFactory)
+            const constructed = new Child("x", dataset, DataFactory)
+
+            assert.equal(child.termType, "NamedNode")
+            assert.equal(child.value, "x")
+            assert.equal(child.equals(constructed as Term), true)
+            assert.equal(child.equals(DataFactory.namedNode("x")), true)
+        })
+
+        await it("wraps a given term instance, like the constructor", async () => {
+            const child = Child.from(DataFactory.blankNode("b1"), dataset, DataFactory)
+
+            assert.equal(child.termType, "BlankNode")
+            assert.equal(child.value, "b1")
+        })
+
+        await it("exposes accessors of the subclass", async () => {
+            const child = Child.from("x", dataset, DataFactory)
+
+            assert.equal(child.hasString, "string 1")
+        })
+
+        await it("keeps references to the dataset and factory", async () => {
+            const child = Child.from("x", dataset, DataFactory)
+
+            assert.equal(child.dataset, dataset)
+            assert.equal(child.factory, DataFactory)
+        })
+    })
+
+    await describe("Intersection return type", async () => {
+        await it("is assignable to term types without casts", async () => {
+            const child = Child.from("x", dataset, DataFactory)
+
+            // Compile-time assertions: no casts in any of the assignments below
+            const node: NamedNode = child
+            const subject: Quad_Subject = child
+
+            assert.equal(node.equals(subject), true)
+        })
+
+        await it("can be used to create quads without casts", async () => {
+            const child = Child.from("x", dataset, DataFactory)
+            const quad = DataFactory.quad(child, DataFactory.namedNode(Example.hasString), DataFactory.literal("string 2"))
+
+            assert.equal(quad.subject.equals(child), true)
+        })
+
+        await it("can be used to match quads in a dataset without casts", async () => {
+            const child = Child.from("x", dataset, DataFactory)
+            const matches = dataset.match(child)
+
+            assert.equal(matches.size, 1)
+        })
+
+        await it("preserves the term type of the wrapped term", async () => {
+            const literal = DataFactory.literal("some value", "en")
+            const wrapped = Child.from(literal, dataset, DataFactory)
+
+            // Compile-time assertion: literal members are available without casts
+            assert.equal(wrapped.language, "en")
+            assert.equal(wrapped.datatype.value, "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")
+        })
+    })
+})


### PR DESCRIPTION
Types the results of the `DatasetWrapper` navigation helpers as both the mapping class and the matched term.

### What it does

- `subjectsOf`, `instancesOf` and `matchSubjectsOf` now return `Iterable<T & Quad_Subject>`, and `objectsOf` and `matchObjectsOf` return `Iterable<T & Quad_Object>`, with the generics constrained to `T extends TermWrapper`. Results can be passed directly anywhere an RDF/JS term is expected — `factory.quad(…)`, `dataset.match(…)` — without casts, and the compiler rejects impossible uses (a matched subject as a `Literal`, a matched object as a `Quad_Subject`, …).
- The helpers construct results with the `TermWrapper.from` static factory (#83) instead of `new`, which is what carries the matched term's type into the instance type.
- `ITermWrapperConstructor<T>` is tightened to the static side of a `TermWrapper` subclass: the familiar constructor signature intersected with `Pick<typeof TermWrapper, "from">`, with `T` constrained (and defaulted) to `TermWrapper`. Any class deriving from `TermWrapper` satisfies it automatically because the static `from` is inherited; classes that merely copy the constructor signature no longer do.
- `TermAs.instance` picks up the matching `T extends TermWrapper` constraint.

Runtime behaviour is unchanged: `from` delegates to the constructor.

### Stacked on #83

The helpers call `TermWrapper.from`, so this branch includes #83's commit; until #83 merges, it shows up in this diff too. Reviewing/merging #83 first reduces this PR to the single `DatasetWrapper`/`ITermWrapperConstructor` commit.

### Relation to #61/#74

Supersedes the dataset-typing slice of #61: the `DatasetWrapper` helper signatures, the `ITermWrapperConstructor` tightening, and its `test/unit/dataset_wrapper_types.test.ts`. One deliberate difference: #61's version of that test asserted that `Literal`/`Quad` members (`.language`, `.subject`, …) do not exist on the results, which relies on #61's restructuring of the `TermWrapper` getters — the contested slice that #85 deliberately leaves out. On top of the current `TermWrapper` those members remain present on every wrapper, so the ported test instead pins down exactly what this slice adds: results are assignable to `Quad_Subject`/`Quad_Object` without casts, and `@ts-expect-error` proves they are not `Literal`/`Quad_Predicate`/`Quad_Subject` where the position rules that out. Should the getter restructuring land later, strengthening these tests to #61's assertions is a small follow-up.

### Testing

- New `test/unit/dataset_wrapper_types.test.ts`: runtime assertions for all five helpers (result counts, mapping-class members) plus compile-level assertions checked by `tsc -p test` — positive (results used as subject/object terms in `factory.quad` and `match` without casts) and negative (`@ts-expect-error` for invalid positions; `ITermWrapperConstructor` satisfied by the `Parent`/`Child` models, rejected for a structurally similar class that does not derive from `TermWrapper`).
- `test/unit/model/ParentDataset.ts` getters updated to the intersection return types (covariant, so the existing `dataset_wrapper.test.ts` is unchanged).
- `npm test`: 149 tests, 0 fail (5 pre-existing skips).
- `npx typedoc`: 0 errors, 6 warnings — identical to `main`.
- `npm audit --omit=dev --audit-level=moderate`: 0 vulnerabilities.

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday-Friday (8-10 July).
