### PR TITLE
feat: symmetric literal mappings — LiteralFrom.bigint and LiteralFrom.symbol

### DIFF
--- a/src/mapping/LiteralFrom.ts
+++ b/src/mapping/LiteralFrom.ts
@@ -23,6 +23,39 @@ export namespace LiteralFrom {
         return factory.literal((value as any).toBase64(), factory.namedNode(XSD.base64Binary))
     }
 
+    /**
+     * {@link ITermFromValueMapping Maps} a big integer to an integer literal.
+     *
+     * @param value - The big integer to convert.
+     * @param factory - A collection of methods for creating terms.
+     * @returns A literal with datatype [`xsd:integer`](https://www.w3.org/TR/xmlschema-2/#integer) whose lexical form is the decimal representation of the value.
+     *
+     * @remarks
+     * This is the term counterpart of the {@link LiteralAs.bigint} value mapping, so integers too large for a JavaScript `number` round-trip through RDF without loss of precision.
+     *
+     * @example Assign a bigint beyond Number.MAX_SAFE_INTEGER
+     * The mapping
+     * ```ts
+     * class Class extends TermWrapper {
+     *     public set property(value: bigint) {
+     *         RequiredAs.object(this, "p", value, LiteralFrom.bigint)
+     *     }
+     * }
+     * ```
+     *
+     * assigned the value `9007199254740993n` produces the RDF
+     * ```turtle
+     * <s> <p> "9007199254740993"^^<xsd:integer> .
+     * ```
+     *
+     * @see
+     * - [`xsd:integer` in XML Schema Part 2: Datatypes](https://www.w3.org/TR/xmlschema-2/#integer)
+     * - [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)
+     */
+    export function bigint(value: bigint, factory: DataFactory): Term {
+        return factory.literal(value.toString(), factory.namedNode(XSD.integer))
+    }
+
     export function boolean(value: boolean, factory: DataFactory): Term {
         return factory.literal(value.toString(), factory.namedNode(XSD.boolean))
     }
@@ -55,6 +88,49 @@ export namespace LiteralFrom {
 
     export function string(value: string, factory: DataFactory): Term {
         return factory.literal(value)
+    }
+
+    /**
+     * {@link ITermFromValueMapping Maps} a registered symbol to a string literal.
+     *
+     * @param value - The symbol to convert. Must be registered in the global symbol registry, i.e. created via [`Symbol.for()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for).
+     * @param factory - A collection of methods for creating terms.
+     * @returns A string literal whose value is the key under which the symbol is registered.
+     *
+     * @remarks
+     * This is the term counterpart of the {@link LiteralAs.symbol} value mapping, which converts literals to symbols via [`Symbol.for()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for).
+     *
+     * Only symbols in the global symbol registry carry a key ([`Symbol.keyFor()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/keyFor)) that can round-trip through RDF, so unregistered symbols (e.g. created via the `Symbol()` function) are rejected.
+     *
+     * @throws {@link !TypeError TypeError} If the symbol is not registered in the global symbol registry.
+     *
+     * @example Assign a registered symbol
+     * The mapping
+     * ```ts
+     * class Class extends TermWrapper {
+     *     public set property(value: symbol) {
+     *         RequiredAs.object(this, "p", value, LiteralFrom.symbol)
+     *     }
+     * }
+     * ```
+     *
+     * assigned the value `Symbol.for("example")` produces the RDF
+     * ```turtle
+     * <s> <p> "example" .
+     * ```
+     *
+     * @see
+     * - [`Symbol.for()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for)
+     * - [`Symbol.keyFor()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/keyFor)
+     */
+    export function symbol(value: symbol, factory: DataFactory): Term {
+        const key = Symbol.keyFor(value)
+
+        if (key === undefined) {
+            throw new TypeError("Symbol must be registered in the global symbol registry")
+        }
+
+        return factory.literal(key)
     }
 
     export function langTuple([key, value]: [string, string], factory: DataFactory): Term {

--- a/test/unit/literalFrom.test.ts
+++ b/test/unit/literalFrom.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from "node:test"
 import { LiteralFrom } from "@rdfjs/wrapper"
 import { DataFactory } from "n3"
 import assert from "node:assert"
+import { Parent } from "./model/Parent.js"
+import { datasetFromRdf } from "./util/datasetFromRdf.js"
 
 const XSD = "http://www.w3.org/2001/XMLSchema#"
 
@@ -19,6 +21,38 @@ await describe("LiteralFrom", async () => {
             const term = LiteralFrom.dateTime(new Date("2026-07-01T08:30:00.000Z"), DataFactory)
             assert.strictEqual(term.value, "2026-07-01T08:30:00.000Z")
             assert.strictEqual((term as any).datatype.value, `${XSD}dateTime`)
+        })
+    })
+
+    await describe("bigint", async () => {
+        await it("produces an xsd:integer lexical", async () => {
+            const term = LiteralFrom.bigint(9007199254740993n, DataFactory)
+            assert.strictEqual(term.value, "9007199254740993")
+            assert.strictEqual((term as any).datatype.value, `${XSD}integer`)
+        })
+
+        await it("round-trips through a model property without loss of precision", async () => {
+            const parent = new Parent("x", datasetFromRdf(""), DataFactory)
+            parent.hasBigint = 9007199254740993n
+            assert.strictEqual(parent.hasBigint, 9007199254740993n)
+        })
+    })
+
+    await describe("symbol", async () => {
+        await it("produces a string literal from a registered symbol", async () => {
+            const term = LiteralFrom.symbol(Symbol.for("example"), DataFactory)
+            assert.strictEqual(term.value, "example")
+            assert.strictEqual((term as any).datatype.value, `${XSD}string`)
+        })
+
+        await it("round-trips through a model property", async () => {
+            const parent = new Parent("x", datasetFromRdf(""), DataFactory)
+            parent.hasSymbol = Symbol.for("example")
+            assert.strictEqual(parent.hasSymbol, Symbol.for("example"))
+        })
+
+        await it("throws a TypeError for a symbol not in the global symbol registry", async () => {
+            assert.throws(() => LiteralFrom.symbol(Symbol("example"), DataFactory), TypeError)
         })
     })
 })

--- a/test/unit/model/Parent.ts
+++ b/test/unit/model/Parent.ts
@@ -18,6 +18,10 @@ import { Example } from "../vocabulary/Example.js"
 
 export class Parent extends TermWrapper {
     /* Value Mapping */
+    public get hasBigint(): bigint {
+        return RequiredFrom.subjectPredicate(this, Example.hasBigint, LiteralAs.bigint)
+    }
+
     public get hasBlankNode(): string {
         return RequiredFrom.subjectPredicate(this, Example.hasBlankNode, LiteralAs.string)
     }
@@ -46,8 +50,16 @@ export class Parent extends TermWrapper {
         return RequiredFrom.subjectPredicate(this, Example.hasIri, LiteralAs.string)
     }
 
+    public get hasSymbol(): symbol {
+        return RequiredFrom.subjectPredicate(this, Example.hasSymbol, LiteralAs.symbol)
+    }
+
 
     /* Term Mapping */
+    public set hasBigint(value: bigint) {
+        RequiredAs.object(this, Example.hasBigint, value, LiteralFrom.bigint)
+    }
+
     public set hasBlankNode(value: string) {
         RequiredAs.object(this, Example.hasBlankNode, value, BlankNodeFrom.string)
     }
@@ -74,6 +86,10 @@ export class Parent extends TermWrapper {
 
     public set hasIri(value: string) {
         RequiredAs.object(this, Example.hasIri, value, NamedNodeFrom.string)
+    }
+
+    public set hasSymbol(value: symbol) {
+        RequiredAs.object(this, Example.hasSymbol, value, LiteralFrom.symbol)
     }
 
 

--- a/test/unit/vocabulary/Example.ts
+++ b/test/unit/vocabulary/Example.ts
@@ -1,5 +1,6 @@
 export const Example = {
     /* Term and Value mapping */
+    hasBigint: "https://example.org/hasBigint",
     hasBlankNode: "https://example.org/hasBlankNode",
     hasDate: "https://example.org/hasDate",
     hasLangString: "https://example.org/hasLangString",
@@ -7,6 +8,7 @@ export const Example = {
     hasBoolean: "https://example.org/hasBoolean",
     hasIri: "https://example.org/hasIri",
     hasString: "https://example.org/hasString",
+    hasSymbol: "https://example.org/hasSymbol",
     /* Object mapping */
     hasChild: "https://example.org/hasChild",
     /* Set mapping */


### PR DESCRIPTION
Part of #7 — the smallest concrete gap there: `LiteralAs.bigint` and `LiteralAs.symbol` exist with no write-side counterparts, so bigint- and symbol-valued model properties can be read but not assigned.

### What this does

Adds the two symmetric term mappings to `LiteralFrom`:

- **`LiteralFrom.bigint(value, factory)`** — maps a `bigint` to an `xsd:integer` literal. Together with `LiteralAs.bigint`, integers beyond `Number.MAX_SAFE_INTEGER` now round-trip through RDF without loss of precision.
- **`LiteralFrom.symbol(value, factory)`** — maps a symbol registered in the global symbol registry (`Symbol.for`) to a plain string literal via `Symbol.keyFor`, mirroring how `LiteralAs.symbol` reads literals back with `Symbol.for`. Unregistered symbols (plain `Symbol()`) carry no key that could round-trip, so they are rejected with a `TypeError` — the same built-in error `ensure.ts` uses for input validation (`TermError` was considered, but its constructor requires an associated RDF/JS `Term`, which does not exist on the write side).

Both carry the dense JSDoc treatment (`@remarks`, paired turtle/ts `@example`, `@throws`, `@see`); `npx typedoc` passes with no new warnings and the cross-links to `LiteralAs.bigint`/`LiteralAs.symbol` resolve.

### Tests

- Direct lexical + datatype assertions for both mappings in `literalFrom.test.ts`.
- Round-trip tests through `Parent` model properties (`hasBigint`, `hasSymbol`) using the existing `RequiredAs`/`RequiredFrom` pattern, including a `bigint` above `Number.MAX_SAFE_INTEGER`.
- The `TypeError` path for unregistered symbols is asserted (new code is fully covered, including both branches of the guard).

### Scope

Deliberately limited to these two mappings to keep the diff reviewable. Further mappings discussed under #7 (`xsd:duration`, `xsd:time`, `xsd:gYear`, `rdf:JSON`, …) are left as follow-ups. This PR does not close #7 and does not overlap with #61, #73 or #74 (none of them touch the `LiteralFrom` write side).

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday-Friday (8-10 July).
