### PR TITLE
docs: document the language-tagged string use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,81 @@ console.log(person1.name)
 ```
 
 
+#### Language-tagged strings
+
+RDF literals can carry a [language tag](https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal) (giving them the `rdf:langString` datatype):
+
+```turtle
+PREFIX ex: <https://example.org/>
+
+ex:person1 ex:label "The librarian"@en .
+```
+
+`LiteralAs.langString` and `LiteralFrom.langString` map such literals to and from `ILangString` objects of the shape `{lang, string}`:
+
+```javascript
+import { LiteralAs, LiteralFrom, RequiredAs, RequiredFrom, TermWrapper } from "https://unpkg.com/@rdfjs/wrapper"
+
+class Person extends TermWrapper {
+	get label() {
+		return RequiredFrom.subjectPredicate(this, "https://example.org/label", LiteralAs.langString)
+	}
+
+	set label(value) {
+		RequiredAs.object(this, "https://example.org/label", value, LiteralFrom.langString)
+	}
+}
+```
+
+Class usage:
+
+```javascript
+const person1 = new Person("https://example.org/person1", dataset, DataFactory)
+
+// Get property
+console.log(person1.label)
+// outputs { lang: "en", string: "The librarian" }
+
+// Set property
+person1.label = { lang: "fr", string: "Le bibliothécaire" }
+console.log(person1.label)
+// outputs { lang: "fr", string: "Le bibliothécaire" }
+```
+
+If you prefer plain tuples over objects, the `LiteralAs.langTuple` and `LiteralFrom.langTuple` mappers translate the same literals to and from `[language, value]` pairs.
+
+When a property holds one value per language, `Mapping.languageDictionary` wraps it as a JavaScript [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) keyed by language tag:
+
+```turtle
+PREFIX ex: <https://example.org/>
+
+ex:person1 ex:label "The librarian"@en, "Le bibliothécaire"@fr .
+```
+
+```javascript
+import { LiteralAs, LiteralFrom, Mapping, TermWrapper } from "https://unpkg.com/@rdfjs/wrapper"
+
+class Person extends TermWrapper {
+	get labels() {
+		return Mapping.languageDictionary(this, "https://example.org/label", LiteralAs.langTuple, LiteralFrom.langTuple)
+	}
+}
+```
+
+Reads and writes through the `Map` are backed by the underlying dataset:
+
+```javascript
+const person1 = new Person("https://example.org/person1", dataset, DataFactory)
+
+console.log(person1.labels.get("en"))
+// outputs "The librarian"
+
+person1.labels.set("hu", "A könyvtáros")
+console.log(person1.labels.size)
+// outputs 3
+```
+
+
 ### Wrapping Datasets
 
 Dataset wrapping lets you find data in a graph that is meant to be wrapped.

--- a/src/mapping/LiteralAs.ts
+++ b/src/mapping/LiteralAs.ts
@@ -40,6 +40,45 @@ export namespace LiteralAs {
         return new Date(term.value)
     }
 
+    /**
+     * {@link ITermAsValueMapping Maps} a language-tagged literal to an {@link ILangString}.
+     *
+     * @param {TermWrapper} term - The term containing a language-tagged string.
+     * @return An {@link ILangString} carrying the term's {@link Literal.language | language tag} (`lang`) and lexical value (`string`).
+     *
+     * @remarks
+     * Only literals with the [`rdf:langString`](https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal) datatype are supported,
+     * which is the datatype of every literal written with a language tag (e.g. `"..."@en`).
+     *
+     * Use {@link langTuple} to map the same literals to plain `[language, value]` tuples instead.
+     *
+     * @throws {@link !ReferenceError ReferenceError} If the term is `undefined` or `null`.
+     * @throws {@link !TypeError TypeError} If the term is not a {@link TermWrapper}.
+     * @throws {@link TermTypeError} If the term is not a {@link Literal}.
+     * @throws {@link LiteralDatatypeError} If the term's datatype is not `rdf:langString`.
+     *
+     * @example Read a language-tagged string
+     * The RDF
+     * ```turtle
+     * <s> <p> "The librarian"@en .
+     * ```
+     *
+     * can be represented by the mapping
+     * ```ts
+     * class Class extends TermWrapper {
+     *     public get property(): ILangString {
+     *         return RequiredFrom.subjectPredicate(this, "p", LiteralAs.langString)
+     *     }
+     * }
+     * ```
+     *
+     * which returns the value `{lang: "en", string: "The librarian"}`.
+     *
+     * @see
+     * - {@link ILangString}
+     * - {@link LiteralFrom.langString} for the inverse mapping
+     * - [Language-tagged strings in RDF 1.1 Concepts and Abstract Syntax](https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal)
+     */
     export function langString(term: TermWrapper): ILangString {
         ensurePresent(term)
         ensureIs(term, TermWrapper)
@@ -173,6 +212,65 @@ export namespace LiteralAs {
         return new URL(term.value)
     }
 
+    /**
+     * {@link ITermAsValueMapping Maps} a language-tagged literal to a `[language, value]` tuple.
+     *
+     * @param {TermWrapper} term - The term containing a language-tagged string.
+     * @return A tuple of the term's {@link Literal.language | language tag} and lexical value.
+     *
+     * @remarks
+     * Only literals with the [`rdf:langString`](https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal) datatype are supported,
+     * which is the datatype of every literal written with a language tag (e.g. `"..."@en`).
+     *
+     * Paired with {@link LiteralFrom.langTuple}, this mapper is suited as the read half of
+     * {@link Mapping.languageDictionary}, which wraps a predicate holding one value per language as a `Map`.
+     *
+     * Use {@link langString} to map the same literals to {@link ILangString} objects instead.
+     *
+     * @throws {@link !ReferenceError ReferenceError} If the term is `undefined` or `null`.
+     * @throws {@link !TypeError TypeError} If the term is not a {@link TermWrapper}.
+     * @throws {@link TermTypeError} If the term is not a {@link Literal}.
+     * @throws {@link LiteralDatatypeError} If the term's datatype is not `rdf:langString`.
+     *
+     * @example Read a language-tagged string as a tuple
+     * The RDF
+     * ```turtle
+     * <s> <p> "The librarian"@en .
+     * ```
+     *
+     * can be represented by the mapping
+     * ```ts
+     * class Class extends TermWrapper {
+     *     public get property(): [string, string] {
+     *         return RequiredFrom.subjectPredicate(this, "p", LiteralAs.langTuple)
+     *     }
+     * }
+     * ```
+     *
+     * which returns the value `["en", "The librarian"]`.
+     *
+     * @example Wrap language-tagged strings as a dictionary
+     * The RDF
+     * ```turtle
+     * <s> <p> "The librarian"@en, "Le bibliothécaire"@fr .
+     * ```
+     *
+     * can be represented by the mapping
+     * ```ts
+     * class Class extends TermWrapper {
+     *     public get property(): Map<string, string> {
+     *         return Mapping.languageDictionary(this, "p", LiteralAs.langTuple, LiteralFrom.langTuple)
+     *     }
+     * }
+     * ```
+     *
+     * which returns a map of `"en" => "The librarian", "fr" => "Le bibliothécaire"`.
+     *
+     * @see
+     * - {@link LiteralFrom.langTuple} for the inverse mapping
+     * - {@link Mapping.languageDictionary}
+     * - [Language-tagged strings in RDF 1.1 Concepts and Abstract Syntax](https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal)
+     */
     export function langTuple(term: TermWrapper): [string, string] {
         ensurePresent(term)
         ensureIs(term, TermWrapper)


### PR DESCRIPTION
Documents the language-tagged string (`rdf:langString`) use case. Support already exists (`ILangString`, `LiteralAs.langString`/`langTuple`, `LiteralFrom.langString`/`langTuple`, `Mapping.languageDictionary`) and is covered by the existing test suite — this PR only adds the missing documentation. No behaviour change.

Closes #75

## What it does

- **README**: adds a *Language-tagged strings* subsection under *Wrapping Terms* with:
  - a turtle snippet (`"The librarian"@en`) and a getter/setter mapping class using `LiteralAs.langString` / `LiteralFrom.langString` (`{lang, string}` objects), with usage output;
  - a note on the `langTuple` (`[language, value]`) variants;
  - a `Mapping.languageDictionary` example wrapping a one-value-per-language predicate as a JavaScript `Map`, with usage output.
- **JSDoc**: adds dense documentation to `LiteralAs.langString` and `LiteralAs.langTuple` (summary, `@remarks`, `@throws`, titled `@example` blocks pairing turtle with a mapping class, `@see`), matching the style of the neighbouring `LiteralAs.uInt8Array` docs.

## Checks

- `npx typedoc` passes; all new `{@link}` targets resolve (the only warnings are ones pre-existing on `main`).
- `npm test` green (122 tests, 0 failures); `npm audit --omit=dev --audit-level=moderate` clean.

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday-Friday (8-10 July).
