### PR TITLE
feat(events): WrappingSet.on/off with mapped values

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@jeswr/eventful-dataset": "github:jeswr/eventful-dataset#feat/eventful-dataset",
     "@rdfjs/types": "^2",
     "@types/node": "^26",
     "typescript": "^6",

--- a/src/WrappingSet.ts
+++ b/src/WrappingSet.ts
@@ -1,7 +1,45 @@
+import type { EventfulDatasetCore } from "@jeswr/eventful-dataset"
 import type { ITermAsValueMapping } from "./type/ITermAsValueMapping.js"
 import type { ITermFromValueMapping } from "./type/ITermFromValueMapping.js"
 import type { DatasetCore, Quad, Quad_Object, Quad_Subject, Term } from "@rdfjs/types"
+import { DatasetEventsError } from "./errors/DatasetEventsError.js"
 import { TermWrapper } from "./TermWrapper.js"
+
+/**
+ * Listener invoked when a value is added to or removed from a {@link WrappingSet}.
+ *
+ * The kind of mutation (`"add"` or `"delete"`) is supplied alongside the JavaScript value that the object of the affected quad maps to.
+ *
+ * @template T - The type of value contained in the observed {@link WrappingSet}.
+ * @param event - `"add"` when a matching quad was added to the underlying dataset, `"delete"` when one was removed.
+ * @param value - The object of the affected quad, converted by the {@link ITermAsValueMapping | mapping} the set was created with.
+ *
+ * @see
+ * - {@link WrappingSet.on}
+ * - {@link WrappingSet.off}
+ */
+export type WrappingSetListener<T> = (event: "add" | "delete", value: T) => void
+
+/**
+ * The dataset surface required for change subscriptions: a {@link DatasetCore} that is also a Node.js [EventEmitter](https://nodejs.org/api/events.html#class-eventemitter) emitting `"add"` and `"delete"` events carrying the affected quad, as implemented by `EventfulDatasetCore` from the [@jeswr/eventful-dataset](https://github.com/jeswr/eventful-dataset) package.
+ */
+type EventfulDatasetLike = DatasetCore & Pick<EventfulDatasetCore, "on" | "off">
+
+/**
+ * The pair of dataset-level event handlers created by a single {@link WrappingSet.on} call, remembered together with the dataset they were attached to so {@link WrappingSet.off} can detach them later.
+ */
+type ListenerAdapter = {
+    dataset: EventfulDatasetLike
+    add: (quad: Quad) => void
+    delete: (quad: Quad) => void
+}
+
+/**
+ * Registry of dataset-level adapters created by {@link WrappingSet.on}, keyed by the user listener so {@link WrappingSet.off} can detach the correct adapter even when called on a different {@link WrappingSet} instance that targets the same subject and predicate. That is the common case, because mappers like {@link SetFrom.subjectPredicate} construct a fresh {@link WrappingSet} on each property access.
+ *
+ * The inner key is `<subject value>\u0000<predicate IRI>`. The literal NUL byte is used as a separator because it cannot appear in an IRI, so the key is unambiguous.
+ */
+const listenerAdapters = new WeakMap<WrappingSetListener<any>, Map<string, ListenerAdapter>>()
 
 export class WrappingSet<T> implements Set<T> {
     // TODO: Direction
@@ -84,4 +122,150 @@ export class WrappingSet<T> implements Set<T> {
         const p = this.subject.factory.namedNode(this.predicate)
         return this.subject.dataset.match(this.subject as Term, p)
     }
+
+    //#region Events
+
+    /**
+     * Subscribes `listener` to additions and removals on this set.
+     *
+     * @remarks
+     * Internally this filters the underlying dataset's change events for quads whose subject and predicate match this set, converts their objects to JavaScript values via the {@link ITermAsValueMapping | mapping} the set was created with, and forwards the result to `listener`. Mutations performed through any other route (the dataset itself, sibling wrappers, etc.) are therefore also observed, provided they affect this set's subject and predicate.
+     *
+     * Change events are only available when the underlying dataset emits them, i.e. when it is also a Node.js [EventEmitter](https://nodejs.org/api/events.html#class-eventemitter) emitting `"add"` and `"delete"` events carrying the affected quad, such as `EventfulDatasetCore` from the [@jeswr/eventful-dataset](https://github.com/jeswr/eventful-dataset) package.
+     *
+     * The same `listener` may be passed to {@link off} on any {@link WrappingSet} that targets the same subject and predicate, not just this instance. Subscribing the same `listener` again for the same subject and predicate replaces the previous subscription, so events are never delivered to a listener twice.
+     *
+     * @example Observing a set-valued property
+     * Assume the following RDF data:
+     * ```turtle
+     * BASE <http://example.com/>
+     *
+     * <someSubject> <someProperty> "some value" .
+     * ```
+     *
+     * A model exposes the objects of `someProperty` as a set of strings:
+     * ```ts
+     * class SomeClass extends TermWrapper {
+     *   get someProperty(): WrappingSet<string> {
+     *     return SetFrom.subjectPredicate(this, "http://example.com/someProperty", LiteralAs.string, LiteralFrom.string)
+     *   }
+     * }
+     *
+     * // eventfulDataset emits "add" and "delete" quad events, e.g. an EventfulDatasetCore
+     * const instance = new SomeClass("http://example.com/someSubject", eventfulDataset, DataFactory)
+     *
+     * instance.someProperty.on((event, value) => console.log(event, value))
+     *
+     * instance.someProperty.add("some other value") // logs: add some other value
+     * instance.someProperty.delete("some value")    // logs: delete some value
+     * ```
+     *
+     * @example Listener identity across instances
+     * Mappers like {@link SetFrom.subjectPredicate} return a fresh {@link WrappingSet} on every property access. {@link off} is keyed by listener, subject and predicate rather than by instance, so the following works:
+     * ```ts
+     * instance.someProperty.on(listener)
+     * instance.someProperty.off(listener) // detaches the listener attached above
+     * ```
+     *
+     * @param listener - Invoked with the kind of mutation and the mapped value whenever a quad matching this set's subject and predicate is added to or removed from the underlying dataset.
+     * @throws A {@link DatasetEventsError} when the underlying dataset does not emit change events.
+     *
+     * @see
+     * - {@link WrappingSetListener}
+     * - {@link off}
+     * - [RDF/JS: Dataset specification](https://rdf.js.org/dataset-spec/)
+     */
+    public on(listener: WrappingSetListener<T>): void {
+        const dataset = this.eventfulDataset
+        const subject = this.subject as Term
+        const predicate = this.subject.factory.namedNode(this.predicate)
+        const source = this.subject.dataset
+        const factory = this.subject.factory
+        const termAs = this.termAs
+
+        const project = (event: "add" | "delete") => (quad: Quad): void => {
+            if (!subject.equals(quad.subject) || !predicate.equals(quad.predicate)) {
+                return
+            }
+
+            listener(event, termAs(new TermWrapper(quad.object, source, factory)))
+        }
+
+        const adapter: ListenerAdapter = { dataset, add: project("add"), delete: project("delete") }
+
+        let adapters = listenerAdapters.get(listener)
+        if (adapters === undefined) {
+            adapters = new Map()
+            listenerAdapters.set(listener, adapters)
+        }
+
+        // If the same listener is already attached for this (subject, predicate)
+        // pair - possibly via a sibling instance - detach the old adapter first
+        // so dataset events are never delivered to the listener twice.
+        const existing = adapters.get(this.adapterKey)
+        if (existing !== undefined) {
+            existing.dataset.off("add", existing.add)
+            existing.dataset.off("delete", existing.delete)
+        }
+
+        adapters.set(this.adapterKey, adapter)
+        dataset.on("add", adapter.add)
+        dataset.on("delete", adapter.delete)
+    }
+
+    /**
+     * Detaches a listener previously attached with {@link on}.
+     *
+     * @remarks
+     * The same function reference must be supplied; unknown listeners are ignored. It is safe to call this on a different {@link WrappingSet} instance than the one used for {@link on}, as long as both target the same subject and predicate.
+     *
+     * @param listener - The listener to detach.
+     *
+     * @see
+     * - {@link WrappingSetListener}
+     * - {@link on}
+     */
+    public off(listener: WrappingSetListener<T>): void {
+        const adapters = listenerAdapters.get(listener)
+        if (adapters === undefined) {
+            return
+        }
+
+        const adapter = adapters.get(this.adapterKey)
+        if (adapter === undefined) {
+            return
+        }
+
+        adapters.delete(this.adapterKey)
+        if (adapters.size === 0) {
+            listenerAdapters.delete(listener)
+        }
+
+        adapter.dataset.off("add", adapter.add)
+        adapter.dataset.off("delete", adapter.delete)
+    }
+
+    /**
+     * The underlying dataset, verified to emit change events.
+     *
+     * @throws A {@link DatasetEventsError} when the underlying dataset does not emit change events.
+     */
+    private get eventfulDataset(): EventfulDatasetLike {
+        const dataset = this.subject.dataset as Partial<EventfulDatasetLike> & DatasetCore
+
+        if (typeof dataset.on !== "function" || typeof dataset.off !== "function") {
+            throw new DatasetEventsError(this.subject.dataset)
+        }
+
+        return dataset as EventfulDatasetLike
+    }
+
+    /**
+     * Stable identity for this set's (subject, predicate) pair, used as the inner key into the listener registry. The NUL separator cannot appear in an IRI, so the key is unambiguous.
+     */
+    private get adapterKey(): string {
+        return `${this.subject.value}\u0000${this.predicate}`
+    }
+
+    //#endregion
 }

--- a/src/errors/DatasetEventsError.ts
+++ b/src/errors/DatasetEventsError.ts
@@ -1,0 +1,24 @@
+import { WrapperError } from "./WrapperError.js"
+import type { DatasetCore } from "@rdfjs/types"
+
+/**
+ * Thrown when change notifications are requested over a dataset that does not emit them.
+ *
+ * @remarks
+ * Subscribing to changes (for example via {@link WrappingSet.on}) requires the underlying {@link DatasetCore} to also be a Node.js [EventEmitter](https://nodejs.org/api/events.html#class-eventemitter) that emits `"add"` and `"delete"` events carrying the affected quad, such as `EventfulDatasetCore` from the [@jeswr/eventful-dataset](https://github.com/jeswr/eventful-dataset) package.
+ *
+ * @see
+ * - {@link WrappingSet.on}
+ * - {@link DatasetCore}
+ */
+export class DatasetEventsError extends WrapperError {
+    /**
+     * Creates a new instance of {@link DatasetEventsError}.
+     *
+     * @param dataset - The dataset that does not emit change events.
+     * @param cause - The specific original cause of the error.
+     */
+    constructor(public readonly dataset: DatasetCore, cause?: any) {
+        super("Dataset does not emit change events. Use a dataset that emits 'add' and 'delete' quad events, like EventfulDatasetCore.", cause)
+    }
+}

--- a/src/mapping/SetFrom.ts
+++ b/src/mapping/SetFrom.ts
@@ -7,7 +7,7 @@ import { WrappingSet } from "../WrappingSet.js"
  * A collection of {@link ITermFromValueMapping | mappers} that expose RDF/JS graph patterns as mutable JavaScript {@link Set | sets}.
  */
 export namespace SetFrom {
-    export function subjectPredicate<T>(anchor: TermWrapper, p: string, termAs: ITermAsValueMapping<T>, termFrom: ITermFromValueMapping<T>): Set<T> {
+    export function subjectPredicate<T>(anchor: TermWrapper, p: string, termAs: ITermAsValueMapping<T>, termFrom: ITermFromValueMapping<T>): WrappingSet<T> {
         if (termAs === undefined) {
             throw new Error // TODO: Describe
         }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -20,6 +20,7 @@ export * from "./mapping/RequiredAs.js"
 
 export * from "./DatasetWrapper.js"
 export * from "./TermWrapper.js"
+export * from "./WrappingSet.js"
 export * from "./NamedGraphDataset.js"
 
 export * from "./errors/WrapperError.js"
@@ -29,3 +30,4 @@ export * from "./errors/LiteralDatatypeError.js"
 export * from "./errors/ListRootError.js"
 export * from "./errors/QuadError.js"
 export * from "./errors/NamedGraphError.js"
+export * from "./errors/DatasetEventsError.js"

--- a/test/unit/util/eventfulDatasetFromRdf.ts
+++ b/test/unit/util/eventfulDatasetFromRdf.ts
@@ -1,0 +1,6 @@
+import { EventfulDatasetCore } from "@jeswr/eventful-dataset"
+import { Parser } from "n3"
+
+export function eventfulDatasetFromRdf(rdf: string): EventfulDatasetCore {
+    return new EventfulDatasetCore(new Parser().parse(rdf))
+}

--- a/test/unit/wrapping_set_events.test.ts
+++ b/test/unit/wrapping_set_events.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert"
+import { describe, it } from "node:test"
+import { DataFactory } from "n3"
+import {
+    DatasetEventsError,
+    LiteralAs,
+    LiteralFrom,
+    SetFrom,
+    TermAs,
+    TermFrom,
+    TermWrapper,
+    WrappingSet,
+    type WrappingSetListener
+} from "@rdfjs/wrapper"
+import { datasetFromRdf } from "./util/datasetFromRdf.js"
+import { eventfulDatasetFromRdf } from "./util/eventfulDatasetFromRdf.js"
+
+const EX = "https://example.org/"
+const HAS_CHILD = `${EX}hasChild`
+const HAS_NICKNAME = `${EX}hasNickname`
+
+class Person extends TermWrapper {
+    public get children(): WrappingSet<Person> {
+        return SetFrom.subjectPredicate(this, HAS_CHILD, TermAs.instance(Person), TermFrom.instance)
+    }
+
+    public get nicknames(): WrappingSet<string> {
+        return SetFrom.subjectPredicate(this, HAS_NICKNAME, LiteralAs.string, LiteralFrom.string)
+    }
+}
+
+/**
+ * Subscribes a recorder to `set` and returns the captured events plus a
+ * `stop` function that detaches it again.
+ *
+ * Events are recorded as `"<event>:<projected value>"` so the tests can
+ * assert exactly which values were added or removed.
+ */
+function recordEvents<T>(set: WrappingSet<T>, project: (value: T) => string): { events: string[], stop: () => void } {
+    const events: string[] = []
+    const listener: WrappingSetListener<T> = (event, value) => {
+        events.push(`${event}:${project(value)}`)
+    }
+    set.on(listener)
+    return { events, stop: () => set.off(listener) }
+}
+
+await describe("Wrapping set events", async () => {
+    await it("emits add events with the mapped value", () => {
+        const dataset = eventfulDatasetFromRdf("")
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+        const bob = new Person(`${EX}bob`, dataset, DataFactory)
+        const carol = new Person(`${EX}carol`, dataset, DataFactory)
+        const { events, stop } = recordEvents(alice.children, child => child.value)
+
+        alice.children.add(bob)
+        alice.children.add(carol)
+
+        assert.deepEqual(events, [`add:${EX}bob`, `add:${EX}carol`])
+        assert.deepEqual(Array.from(alice.children, child => child.value).sort(), [`${EX}bob`, `${EX}carol`])
+        stop()
+    })
+
+    await it("projects literal objects through the configured mapping", () => {
+        const dataset = eventfulDatasetFromRdf(`<${EX}alice> <${HAS_NICKNAME}> "Alice" .`)
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+        const { events, stop } = recordEvents(alice.nicknames, value => value)
+
+        alice.nicknames.add("Ally")
+        alice.nicknames.delete("Alice")
+
+        assert.deepEqual(events, ["add:Ally", "delete:Alice"])
+        stop()
+    })
+
+    await it("emits delete events for removals and clear()", () => {
+        const dataset = eventfulDatasetFromRdf(`<${EX}alice> <${HAS_CHILD}> <${EX}bob>, <${EX}carol> .`)
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+        const bob = new Person(`${EX}bob`, dataset, DataFactory)
+        const { events, stop } = recordEvents(alice.children, child => child.value)
+
+        alice.children.delete(bob)
+        alice.children.clear()
+
+        assert.deepEqual(events, [`delete:${EX}bob`, `delete:${EX}carol`])
+        assert.equal(alice.children.size, 0)
+        stop()
+    })
+
+    await it("re-iterating the set inside the listener observes a live view", () => {
+        const dataset = eventfulDatasetFromRdf("")
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+        const snapshots: string[][] = []
+        const listener: WrappingSetListener<Person> = () => {
+            snapshots.push(Array.from(alice.children, child => child.value).sort())
+        }
+        alice.children.on(listener)
+
+        alice.children.add(new Person(`${EX}bob`, dataset, DataFactory))
+        alice.children.add(new Person(`${EX}carol`, dataset, DataFactory))
+        alice.children.add(new Person(`${EX}dave`, dataset, DataFactory))
+
+        assert.deepEqual(snapshots, [
+            [`${EX}bob`],
+            [`${EX}bob`, `${EX}carol`],
+            [`${EX}bob`, `${EX}carol`, `${EX}dave`]
+        ])
+        alice.children.off(listener)
+    })
+
+    await it("ignores changes on other subjects or predicates", () => {
+        const dataset = eventfulDatasetFromRdf("")
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+        const eve = new Person(`${EX}eve`, dataset, DataFactory)
+        const { events, stop } = recordEvents(alice.children, child => child.value)
+
+        // A child added to a different subject must not surface on Alice's set.
+        eve.children.add(new Person(`${EX}mallory`, dataset, DataFactory))
+        // A different predicate on Alice must not surface either.
+        alice.nicknames.add("Ally")
+
+        assert.deepEqual(events, [])
+        stop()
+    })
+
+    await it("observes mutations made directly on the dataset", () => {
+        const dataset = eventfulDatasetFromRdf("")
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+        const { events, stop } = recordEvents(alice.children, child => child.value)
+        const quad = DataFactory.quad(
+            DataFactory.namedNode(`${EX}alice`),
+            DataFactory.namedNode(HAS_CHILD),
+            DataFactory.namedNode(`${EX}bob`)
+        )
+
+        dataset.add(quad)
+        dataset.delete(quad)
+
+        assert.deepEqual(events, [`add:${EX}bob`, `delete:${EX}bob`])
+        stop()
+    })
+
+    await it("emits nothing when adding a value that is already in the set", () => {
+        const dataset = eventfulDatasetFromRdf(`<${EX}alice> <${HAS_CHILD}> <${EX}bob> .`)
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+        const bob = new Person(`${EX}bob`, dataset, DataFactory)
+        const { events, stop } = recordEvents(alice.children, child => child.value)
+
+        alice.children.add(bob)
+
+        assert.deepEqual(events, [])
+        stop()
+    })
+
+    await it("supports multiple independent listeners on the same set", () => {
+        const dataset = eventfulDatasetFromRdf("")
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+        const first = recordEvents(alice.children, child => child.value)
+        const second = recordEvents(alice.children, child => child.value)
+
+        alice.children.add(new Person(`${EX}bob`, dataset, DataFactory))
+
+        assert.deepEqual(first.events, [`add:${EX}bob`])
+        assert.deepEqual(second.events, [`add:${EX}bob`])
+        first.stop()
+        second.stop()
+    })
+
+    await describe("off", async () => {
+        await it("detaches the listener across fresh instances", () => {
+            const dataset = eventfulDatasetFromRdf("")
+            const alice = new Person(`${EX}alice`, dataset, DataFactory)
+            const events: string[] = []
+            const listener: WrappingSetListener<Person> = (event, child) => {
+                events.push(`${event}:${child.value}`)
+            }
+
+            // Each property access constructs a fresh WrappingSet, so this
+            // exercises detaching via a different instance than was used
+            // for on().
+            alice.children.on(listener)
+            alice.children.off(listener)
+
+            alice.children.add(new Person(`${EX}bob`, dataset, DataFactory))
+
+            assert.deepEqual(events, [])
+        })
+
+        await it("ignores a listener that was never attached", () => {
+            const dataset = eventfulDatasetFromRdf("")
+            const alice = new Person(`${EX}alice`, dataset, DataFactory)
+
+            assert.doesNotThrow(() => alice.children.off(() => undefined))
+        })
+
+        await it("does not detach a listener attached to a different subject", () => {
+            const dataset = eventfulDatasetFromRdf("")
+            const alice = new Person(`${EX}alice`, dataset, DataFactory)
+            const eve = new Person(`${EX}eve`, dataset, DataFactory)
+            const events: string[] = []
+            const listener: WrappingSetListener<Person> = (event, child) => {
+                events.push(`${event}:${child.value}`)
+            }
+            alice.children.on(listener)
+
+            eve.children.off(listener)
+            alice.children.add(new Person(`${EX}bob`, dataset, DataFactory))
+
+            assert.deepEqual(events, [`add:${EX}bob`])
+            alice.children.off(listener)
+        })
+
+        await it("only detaches the given subject and predicate when a listener observes several", () => {
+            const dataset = eventfulDatasetFromRdf("")
+            const alice = new Person(`${EX}alice`, dataset, DataFactory)
+            const events: string[] = []
+            const listener: WrappingSetListener<any> = (event, value) => {
+                events.push(`${event}:${typeof value === "string" ? value : value.value}`)
+            }
+            alice.children.on(listener)
+            alice.nicknames.on(listener)
+
+            alice.children.off(listener)
+            alice.children.add(new Person(`${EX}bob`, dataset, DataFactory))
+            alice.nicknames.add("Ally")
+
+            assert.deepEqual(events, ["add:Ally"])
+            alice.nicknames.off(listener)
+        })
+    })
+
+    await it("replaces the subscription when the same listener is attached again", () => {
+        const dataset = eventfulDatasetFromRdf("")
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+        const events: string[] = []
+        const listener: WrappingSetListener<Person> = (event, child) => {
+            events.push(`${event}:${child.value}`)
+        }
+
+        alice.children.on(listener)
+        alice.children.on(listener)
+
+        alice.children.add(new Person(`${EX}bob`, dataset, DataFactory))
+
+        assert.deepEqual(events, [`add:${EX}bob`])
+        alice.children.off(listener)
+    })
+
+    await it("throws when the underlying dataset does not emit change events", () => {
+        const dataset = datasetFromRdf("")
+        const alice = new Person(`${EX}alice`, dataset, DataFactory)
+
+        assert.throws(() => alice.children.on(() => undefined), DatasetEventsError)
+    })
+})


### PR DESCRIPTION
## What this does

Adds change subscriptions at the collection level: `WrappingSet<T>` gains `on(listener)` / `off(listener)`, with listeners receiving the kind of mutation and the **mapped JavaScript value** rather than a raw quad.

- `WrappingSetListener<T>` — `(event: "add" | "delete", value: T) => void`.
- `on(listener)` subscribes to the underlying dataset's `"add"`/`"delete"` quad events, filters them by this set's subject + predicate, and projects the affected quad's object through the `termAs` mapping the set was created with. Mutations made through any route (the dataset directly, sibling wrappers) are observed.
- `off(listener)` detaches via a `WeakMap<listener, Map<subject␀predicate, adapter>>` registry, so it works across the **fresh instances** `SetFrom.subjectPredicate` returns on every property access (`instance.prop.on(l)` … `instance.prop.off(l)` just works). Re-attaching the same listener for the same subject + predicate replaces the previous subscription, so events are never delivered twice.
- Datasets that don't emit change events are rejected with a new typed `DatasetEventsError` (extends `WrapperError`).

Event-emitting datasets are detected structurally (a `DatasetCore` that is also an EventEmitter with `"add"`/`"delete"` quad events, e.g. `EventfulDatasetCore` from [`@jeswr/eventful-dataset`](https://github.com/jeswr/eventful-dataset)). That package is a **devDependency only** (tests + a type-only import); the emitted declarations do not reference it and the package keeps zero runtime dependencies.

## Relationship to other PRs

- **Supersedes the `WrappingSet` listener slice of #73** — `WrappingSetListener`, `WrappingSet.on`/`off`, and the WeakMap adapter registry keyed by `listener → subject␀predicate`, ported onto `main` without the rest of the omnibus (`NotificationsDatasetCore` is replaced by the structural eventful-dataset surface). #73's set-event behaviour is covered by the ported tests in `test/unit/wrapping_set_events.test.ts`.
- **Overlaps with #92** on exactly two hunks (exporting `WrappingSet` from `mod.ts` and narrowing `SetFrom.subjectPredicate`'s return type to `WrappingSet<T>`); they are textually identical there, so they drop out on rebase once #92 lands. This PR is self-contained against `main` either way.

## Tests

14 new tests (`test/unit/wrapping_set_events.test.ts`): add/delete/clear emission with mapped values (term and literal mappings), subject/predicate filtering, direct dataset mutations, no event on ineffective adds, multiple independent listeners, live re-iteration inside a listener, `off` across fresh instances / unknown listeners / per-(subject, predicate) detachment, re-subscription replacement, and the `DatasetEventsError` path. `npm test` (136 tests, 0 fail), `npx typedoc`, and `npm audit --omit=dev` all pass locally.

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday-Friday (8-10 July).
