### PR TITLE
feat(events): change notifications on DatasetWrapper (on/off)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "Jesse Wright (https://github.com/jeswr)"
   ],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "@jeswr/eventful-dataset": "github:jeswr/eventful-dataset#feat/eventful-dataset"
+  },
   "devDependencies": {
     "@rdfjs/types": "^2",
     "@types/node": "^26",

--- a/src/DatasetWrapper.ts
+++ b/src/DatasetWrapper.ts
@@ -1,14 +1,26 @@
+import type { EventfulDatasetCore } from "@jeswr/eventful-dataset"
 import type { DataFactory, DatasetCore, Quad, Quad_Graph, Term } from "@rdfjs/types"
 import type { ITermWrapperConstructor } from "./type/ITermWrapperConstructor.js"
+import type { IDatasetChangeListener } from "./type/IDatasetChangeListener.js"
 import type { NamedGraphDataset } from "./NamedGraphDataset.js"
 import type { INamedGraphDatasetConstructor } from "./type/INamedGraphDatasetConstructor.js"
 
+import { ensureEventfulDatasetCore } from "./ensure.js"
 import { RDF } from "./vocabulary/RDF.js"
 
 export class DatasetWrapper implements DatasetCore {
     //#region DatasetCore
 
-    public constructor(private readonly dataset: DatasetCore, protected readonly factory: DataFactory) {
+    private readonly dataset: EventfulDatasetCore<Quad>
+
+    /**
+     * Creates a new instance of {@link DatasetWrapper}.
+     *
+     * @param dataset - The dataset being wrapped. Mutations performed through this wrapper write through to it and notify listeners attached with {@link on}.
+     * @param factory - A collection of methods for creating terms.
+     */
+    public constructor(dataset: DatasetCore, protected readonly factory: DataFactory) {
+        this.dataset = ensureEventfulDatasetCore(dataset)
     }
 
     public get size(): number {
@@ -35,6 +47,104 @@ export class DatasetWrapper implements DatasetCore {
 
     public match(subject?: Term, predicate?: Term, object?: Term, graph?: Term): DatasetCore {
         return this.dataset.match(subject, predicate, object, graph)
+    }
+
+    //#endregion
+
+    //#region Events
+
+    private readonly listeners = new Map<IDatasetChangeListener, { added(quad: Quad): void, deleted(quad: Quad): void }>()
+
+    /**
+     * Subscribes `listener` to change notifications for the underlying dataset.
+     *
+     * The listener is invoked synchronously with the type of the change (`"add"` or `"delete"`) and the affected quad whenever the contents of the dataset effectively change, regardless of how the mutation was performed: direct calls to {@link add} or {@link delete}, assigning a mapped property on a {@link TermWrapper}, or mutating a {@link Set} returned by a {@link SetFrom} mapping.
+     *
+     * @remarks
+     * - Only effective changes are notified: adding a quad that the dataset already contains, or deleting one that it does not, does not invoke the listener.
+     * - Property assignments do not deduplicate: mutators remove existing quads before adding the new one, so assigning a value emits a `"delete"` notification for every quad previously matching the property (if any), followed by an `"add"` notification for the new quad - even when the assigned value equals the current one. Clearing an optional property (assigning `undefined`) emits only `"delete"` notifications.
+     * - Subscribing a listener that is already subscribed has no effect. Listeners are notified in subscription order.
+     * - Only mutations performed through this wrapper (or through another wrapper sharing the same underlying eventful dataset, such as views created by {@link named}) are observed. Mutating the wrapped dataset directly does not notify listeners.
+     *
+     * @param listener - The callback to invoke with every change to the contents of the dataset.
+     *
+     * @example Observing property assignments
+     * Assume the following RDF data:
+     * ```turtle
+     * BASE <http://example.com/>
+     *
+     * <someSubject> <someProperty> "some value" .
+     * ```
+     *
+     * Given the mapping
+     * ```ts
+     * class SomeClass extends TermWrapper {
+     *   set someProperty(value: string) {
+     *     RequiredAs.object(this, "http://example.com/someProperty", value, LiteralFrom.string)
+     *   }
+     * }
+     * ```
+     *
+     * mutations can be observed as follows:
+     * ```ts
+     * const wrapper = new DatasetWrapper(dataset, DataFactory) // which has the RDF above loaded
+     * wrapper.on((event, quad) => console.log(`${event} ${quad.object.value}`))
+     *
+     * const instance = new SomeClass("http://example.com/someSubject", wrapper, DataFactory)
+     * instance.someProperty = "some other value"
+     * // logs `delete some value` followed by `add some other value`
+     * ```
+     *
+     * @example Observing direct mutations
+     * ```ts
+     * const wrapper = new DatasetWrapper(dataset, DataFactory)
+     * wrapper.on((event, quad) => console.log(event))
+     *
+     * wrapper.add(someQuad)    // logs `add` (unless the dataset already contained the quad)
+     * wrapper.delete(someQuad) // logs `delete`
+     * ```
+     *
+     * @see
+     * - {@link off} for detaching the listener.
+     * - {@link IDatasetChangeListener} for the listener signature.
+     * - [RDF/JS: Dataset specification](https://rdf.js.org/dataset-spec/)
+     */
+    public on(listener: IDatasetChangeListener): void {
+        if (this.listeners.has(listener)) {
+            return
+        }
+
+        const handlers = {
+            added: (quad: Quad) => listener("add", quad),
+            deleted: (quad: Quad) => listener("delete", quad),
+        }
+
+        this.listeners.set(listener, handlers)
+        this.dataset.on("add", handlers.added)
+        this.dataset.on("delete", handlers.deleted)
+    }
+
+    /**
+     * Unsubscribes `listener` from change notifications for the underlying dataset.
+     *
+     * @remarks
+     * The argument must be the same function reference that was passed to {@link on}. Detaching a listener that is not subscribed has no effect.
+     *
+     * @param listener - The callback to detach.
+     *
+     * @see
+     * - {@link on} for attaching a listener.
+     */
+    public off(listener: IDatasetChangeListener): void {
+        const handlers = this.listeners.get(listener)
+
+        if (handlers === undefined) {
+            return
+        }
+
+        this.listeners.delete(listener)
+        this.dataset.off("add", handlers.added)
+        this.dataset.off("delete", handlers.deleted)
     }
 
     //#endregion

--- a/src/ensure.ts
+++ b/src/ensure.ts
@@ -1,4 +1,5 @@
-import type { DefaultGraph, Literal, Quad, Term } from "@rdfjs/types"
+import type { DatasetCore, DefaultGraph, Literal, Quad, Term } from "@rdfjs/types"
+import { EventfulDatasetCore } from "@jeswr/eventful-dataset"
 import { TermTypeError } from "./errors/TermTypeError.js"
 import { LiteralDatatypeError } from "./errors/LiteralDatatypeError.js"
 import type { IRdfJsTerm } from "./type/IRdfJsTerm.js"
@@ -56,5 +57,32 @@ export function ensureDefaultGraph(quad: Quad): asserts quad is Quad & { graph: 
     }
 
     throw new NamedGraphError(quad)
+}
+
+/**
+ * Returns `dataset` if it is already an {@link EventfulDatasetCore}, otherwise wraps it in one so that mutations can be observed.
+ *
+ * The wrapped dataset remains the single place of storage: additions and deletions performed through the returned {@link EventfulDatasetCore} write through to `dataset`, so external references to `dataset` observe all changes made through the eventful layer.
+ */
+export function ensureEventfulDatasetCore(dataset: DatasetCore): EventfulDatasetCore<Quad> {
+    if (dataset instanceof EventfulDatasetCore) {
+        return dataset
+    }
+
+    // An EventfulDatasetCore delegates storage to a dataset created by the factory it is constructed with.
+    // This factory returns the dataset being wrapped on the first invocation (the storage of the eventful layer, so that mutations write through to the original dataset) and creates fresh, independent datasets on subsequent invocations (the snapshots returned by EventfulDatasetCore.match).
+    let storage: DatasetCore | undefined = dataset
+
+    return new EventfulDatasetCore<Quad>(undefined, {
+        dataset(quads?: Quad[]): DatasetCore {
+            if (storage !== undefined) {
+                const wrapped = storage
+                storage = undefined
+                return wrapped
+            }
+
+            return new EventfulDatasetCore<Quad>(quads)
+        },
+    })
 }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -3,6 +3,7 @@ export type * from "./type/ITermWrapperConstructor.js"
 export type * from "./type/INamedGraphDatasetConstructor.js"
 export type * from "./type/ITermFromValueMapping.js"
 export type * from "./type/ILangString.js"
+export type * from "./type/IDatasetChangeListener.js"
 
 export * from "./mapping/TermAs.js"
 export * from "./mapping/LiteralAs.js"

--- a/src/type/IDatasetChangeListener.ts
+++ b/src/type/IDatasetChangeListener.ts
@@ -1,0 +1,51 @@
+import type { Quad } from "@rdfjs/types"
+
+/**
+ * The type of change to the contents of a dataset reported to an {@link IDatasetChangeListener}: `"add"` when a quad was added to the dataset, `"delete"` when a quad was removed from it.
+ *
+ * @see
+ * - {@link DatasetWrapper.on}
+ * - {@link DatasetWrapper.off}
+ */
+export type ChangeEvent = "add" | "delete"
+
+/**
+ * Represents the function signature of callbacks that observe changes to the contents of a {@link DatasetWrapper}.
+ *
+ * Used by this library where lambdas are accepted for reacting to quads being added to or removed from the underlying data.
+ *
+ * @remarks
+ * - Listeners are invoked synchronously, once per quad that is effectively added or removed, regardless of whether the change was performed directly on the {@link DatasetWrapper} or indirectly through a mapped property.
+ * - No restrictions are imposed on what listeners do with the notifications, except for the understanding that mutating the dataset from within a listener triggers further notifications.
+ *
+ * @param event - The type of the change: `"add"` or `"delete"`.
+ * @param quad - The quad that was added to or removed from the dataset.
+ *
+ * @example Listener as TypeScript function
+ * ```ts
+ * function listener(event: ChangeEvent, quad: Quad): void {
+ *   console.log(`${event} ${quad.object.value}`)
+ * }
+ * ```
+ *
+ * @example Listener as JavaScript function
+ * ```js
+ * function listener(event, quad) {
+ *   console.log(`${event} ${quad.object.value}`)
+ * }
+ * ```
+ *
+ * @example Listener as TypeScript typed constant
+ * Authoring listeners as typed TypeScript constants helps by compile-time checking that a lambda adheres to the interface.
+ * ```ts
+ * const listener: IDatasetChangeListener = (event, quad) => console.log(`${event} ${quad.object.value}`)
+ * ```
+ *
+ * @see
+ * - {@link DatasetWrapper.on}
+ * - {@link DatasetWrapper.off}
+ * - {@link Quad}
+ */
+export interface IDatasetChangeListener {
+    (event: ChangeEvent, quad: Quad): void
+}

--- a/test/unit/dataset_events.test.ts
+++ b/test/unit/dataset_events.test.ts
@@ -1,0 +1,259 @@
+import assert from "node:assert"
+import { describe, it } from "node:test"
+import type { Quad } from "@rdfjs/types"
+import { DataFactory } from "n3"
+import type { ChangeEvent } from "@rdfjs/wrapper"
+import { datasetFromRdf } from "./util/datasetFromRdf.js"
+import { ParentDataset } from "./model/ParentDataset.js"
+import { Parent } from "./model/Parent.js"
+import { Child } from "./model/Child.js"
+import { Example } from "./vocabulary/Example.js"
+
+const rdf = `
+prefix : <https://example.org/>
+
+<x>
+    a :Parent ;
+    :hasNumber "1.0E0"^^<http://www.w3.org/2001/XMLSchema#double> ;
+    :hasString "o1" ;
+    :hasChild [ :hasString "child string 1" ] ;
+    :hasChildSet [ :hasString "set 1" ], [ :hasString "set 2" ] ;
+    :hasNullableString "nullable" ;
+.
+`;
+
+/**
+ * Subscribes a recorder to a {@link ParentDataset}'s change notifications and returns the captured events plus a `stop` function that detaches the recorder.
+ *
+ * Events are recorded as `"<event>:<predicate>:<object value>"` so the tests can assert exactly which quads were added or removed without caring about subjects (which are stable for a given anchor).
+ */
+function recordEvents(ds: ParentDataset): { events: string[], stop: () => void } {
+    const events: string[] = []
+    const listener = (event: ChangeEvent, q: Quad) => {
+        events.push(`${event}:${q.predicate.value.replace("https://example.org/", "")}:${q.object.value}`)
+    }
+    ds.on(listener)
+    return { events, stop: () => ds.off(listener) }
+}
+
+function quadOf(subject: string, predicate: string, object: string): Quad {
+    return DataFactory.quad(
+        DataFactory.namedNode(subject),
+        DataFactory.namedNode(predicate),
+        DataFactory.literal(object),
+    )
+}
+
+await describe("DatasetWrapper change notifications", async () => {
+    await it("emits an add event when a quad is added directly", () => {
+        const ds = new ParentDataset(datasetFromRdf(""), DataFactory)
+        const { events, stop } = recordEvents(ds)
+
+        ds.add(quadOf("https://example.org/x", Example.hasString, "added"))
+
+        assert.deepEqual(events, ["add:hasString:added"])
+        stop()
+    })
+
+    await it("emits a delete event when a quad is removed directly", () => {
+        // The fixture's `<x>` is a relative IRI, so the parsed subject is plain "x".
+        const ds = new ParentDataset(datasetFromRdf(rdf), DataFactory)
+        const { events, stop } = recordEvents(ds)
+
+        ds.delete(quadOf("x", Example.hasString, "o1"))
+
+        assert.deepEqual(events, ["delete:hasString:o1"])
+        stop()
+    })
+
+    await it("does not emit when adding a quad the dataset already contains", () => {
+        const ds = new ParentDataset(datasetFromRdf(rdf), DataFactory)
+        const { events, stop } = recordEvents(ds)
+
+        ds.add(quadOf("x", Example.hasString, "o1"))
+
+        assert.deepEqual(events, [])
+        stop()
+    })
+
+    await it("does not emit when deleting a quad the dataset does not contain", () => {
+        const ds = new ParentDataset(datasetFromRdf(rdf), DataFactory)
+        const { events, stop } = recordEvents(ds)
+
+        ds.delete(quadOf("https://example.org/x", Example.hasString, "absent"))
+
+        assert.deepEqual(events, [])
+        stop()
+    })
+
+    await it("stops emitting after off() detaches the listener", () => {
+        const ds = new ParentDataset(datasetFromRdf(""), DataFactory)
+        const { events, stop } = recordEvents(ds)
+
+        stop()
+        ds.add(quadOf("https://example.org/x", Example.hasString, "ignored"))
+
+        assert.deepEqual(events, [])
+    })
+
+    await it("detaching a listener that is not subscribed is a no-op", () => {
+        const ds = new ParentDataset(datasetFromRdf(""), DataFactory)
+        const { events, stop } = recordEvents(ds)
+
+        ds.off(() => { })
+        ds.add(quadOf("https://example.org/x", Example.hasString, "observed"))
+
+        assert.deepEqual(events, ["add:hasString:observed"])
+        stop()
+    })
+
+    await it("supports multiple independent listeners", () => {
+        const ds = new ParentDataset(datasetFromRdf(""), DataFactory)
+        const a: ChangeEvent[] = []
+        const b: ChangeEvent[] = []
+        ds.on(event => { a.push(event) })
+        ds.on(event => { b.push(event) })
+
+        ds.add(quadOf("https://example.org/x", Example.hasString, "v"))
+
+        assert.deepEqual(a, ["add"])
+        assert.deepEqual(b, ["add"])
+    })
+
+    await it("subscribing the same listener twice notifies it once", () => {
+        const ds = new ParentDataset(datasetFromRdf(""), DataFactory)
+        const events: ChangeEvent[] = []
+        const listener = (event: ChangeEvent) => { events.push(event) }
+        ds.on(listener)
+        ds.on(listener)
+
+        ds.add(quadOf("https://example.org/x", Example.hasString, "v"))
+
+        assert.deepEqual(events, ["add"])
+        ds.off(listener)
+        ds.add(quadOf("https://example.org/x", Example.hasString, "w"))
+        assert.deepEqual(events, ["add"])
+    })
+})
+
+await describe("Wrapper-driven change notifications", async () => {
+    /** Returns the singleton `<x>` parent in the test fixture. */
+    function load(): { ds: ParentDataset, parent: Parent } {
+        const ds = new ParentDataset(datasetFromRdf(rdf), DataFactory)
+        const [parent] = Array.from(ds.instancesOfParent)
+        return { ds, parent: parent! }
+    }
+
+    await it("setting a required property to a new value emits delete then add", () => {
+        const { ds, parent } = load()
+        const { events, stop } = recordEvents(ds)
+
+        parent.hasString = "o2"
+
+        assert.deepEqual(events, ["delete:hasString:o1", "add:hasString:o2"])
+        stop()
+    })
+
+    await it("setting a required property to its current value still emits both events", () => {
+        // OptionalAs.object always deletes existing matching quads before adding the new one, so a "no-op" assignment surfaces as two effective mutations.
+        const { ds, parent } = load()
+        const { events, stop } = recordEvents(ds)
+
+        parent.hasString = "o1"
+
+        assert.deepEqual(events, ["delete:hasString:o1", "add:hasString:o1"])
+        stop()
+    })
+
+    await it("clearing an optional property emits only a delete", () => {
+        const { ds, parent } = load()
+        const { events, stop } = recordEvents(ds)
+
+        parent.hasNullableString = undefined
+
+        assert.deepEqual(events, ["delete:hasNullableString:nullable"])
+        stop()
+    })
+
+    await it("clearing an already-empty optional property emits nothing", () => {
+        const { ds, parent } = load()
+        parent.hasNullableString = undefined
+        const { events, stop } = recordEvents(ds)
+
+        parent.hasNullableString = undefined
+
+        assert.deepEqual(events, [])
+        stop()
+    })
+
+    await it("setting an optional property from undefined emits only an add", () => {
+        const { ds, parent } = load()
+        parent.hasNullableString = undefined
+        const { events, stop } = recordEvents(ds)
+
+        parent.hasNullableString = "first"
+
+        assert.deepEqual(events, ["add:hasNullableString:first"])
+        stop()
+    })
+
+    await it("changing a typed (number) property emits delete + add for the typed literal", () => {
+        const { ds, parent } = load()
+        const { events, stop } = recordEvents(ds)
+
+        parent.hasNumber = 2
+
+        assert.deepEqual(events, [
+            "delete:hasNumber:1.0E0",
+            "add:hasNumber:2",
+        ])
+        stop()
+    })
+
+    await it("adding to a Set-mapped property emits a single add", () => {
+        const { ds, parent } = load()
+        const { events, stop } = recordEvents(ds)
+
+        const newChild = new Child(DataFactory.namedNode("https://example.org/new-child"), ds, DataFactory)
+        parent.hasChildSet.add(newChild)
+
+        assert.deepEqual(events, ["add:hasChildSet:https://example.org/new-child"])
+        stop()
+    })
+
+    await it("removing from a Set-mapped property emits a single delete", () => {
+        const { ds, parent } = load()
+        const [first] = Array.from(parent.hasChildSet)
+        const { events, stop } = recordEvents(ds)
+
+        parent.hasChildSet.delete(first!)
+
+        assert.deepEqual(events, [`delete:hasChildSet:${first!.value}`])
+        stop()
+    })
+
+    await it("removing a value not in the Set is a no-op and emits nothing", () => {
+        const { ds, parent } = load()
+        const { events, stop } = recordEvents(ds)
+
+        const stranger = new Child(DataFactory.namedNode("https://example.org/stranger"), ds, DataFactory)
+        parent.hasChildSet.delete(stranger)
+
+        assert.deepEqual(events, [])
+        stop()
+    })
+
+    await it("clearing a Set-mapped property emits a delete per remaining item", () => {
+        const { ds, parent } = load()
+        const childIris = Array.from(parent.hasChildSet, c => c.value).sort()
+        const { events, stop } = recordEvents(ds)
+
+        parent.hasChildSet.clear()
+
+        assert.deepEqual(
+            events.sort(),
+            childIris.map(iri => `delete:hasChildSet:${iri}`).sort(),
+        )
+        stop()
+    })
+})

--- a/test/unit/dataset_events_examples.test.ts
+++ b/test/unit/dataset_events_examples.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert"
+import { describe, it } from "node:test"
+import { DataFactory } from "n3"
+import {
+    DatasetWrapper,
+    LiteralAs,
+    LiteralFrom,
+    OptionalAs,
+    OptionalFrom,
+    SetFrom,
+    TermAs,
+    TermFrom,
+    TermWrapper,
+} from "@rdfjs/wrapper"
+import { datasetFromRdf } from "./util/datasetFromRdf.js"
+
+const EX = "https://example.org/"
+const HAS_CHILD = `${EX}hasChild`
+const HAS_EMAIL = `${EX}hasEmail`
+
+class Person extends TermWrapper {
+    /**
+     * A live, mutable {@link Set} of this person's children, backed by `<this> :hasChild ?child` quads in the dataset. Iteration always reflects the current state of the dataset; calling `add()` / `delete()` / `clear()` writes through to the underlying graph and triggers change notifications on the containing {@link DatasetWrapper}.
+     */
+    public get children(): Set<Person> {
+        return SetFrom.subjectPredicate(
+            this,
+            HAS_CHILD,
+            TermAs.instance(Person),
+            TermFrom.instance,
+        )
+    }
+
+    /**
+     * Optional email address. Setting to a string emits `delete` (of any previous value) followed by `add`. Setting to `undefined` emits only `delete`, or nothing if there was no previous value.
+     */
+    public get email(): string | undefined {
+        return OptionalFrom.subjectPredicate(this, HAS_EMAIL, LiteralAs.string)
+    }
+
+    public set email(value: string | undefined) {
+        OptionalAs.object(this, HAS_EMAIL, value, LiteralFrom.string)
+    }
+}
+
+class People extends DatasetWrapper {
+    public person(iri: string): Person {
+        return new Person(iri, this, this.factory)
+    }
+}
+
+await describe("Example: observing a children set backed by SetFrom", async () => {
+    await it("emits add events as children are added and the set reflects current state", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        const bob = ds.person(`${EX}bob`)
+        const carol = ds.person(`${EX}carol`)
+
+        const childEvents: string[] = []
+        ds.on((event, quad) => {
+            childEvents.push(`${event}:${quad.object.value}`)
+        })
+
+        assert.equal(alice.children.size, 0)
+
+        alice.children.add(bob)
+        alice.children.add(carol)
+
+        assert.deepEqual(childEvents, [
+            `add:${EX}bob`,
+            `add:${EX}carol`,
+        ])
+
+        // The set always reflects the current state.
+        assert.deepEqual(
+            Array.from(alice.children).map(c => c.value).sort(),
+            [`${EX}bob`, `${EX}carol`],
+        )
+    })
+
+    await it("re-iterating children inside the listener observes new additions", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        const snapshots: string[][] = []
+
+        ds.on(() => {
+            // Each notification captures a fresh snapshot of `alice.children`, proving the set is a live view, not a one-shot copy.
+            snapshots.push(Array.from(alice.children).map(c => c.value))
+        })
+
+        alice.children.add(ds.person(`${EX}bob`))
+        alice.children.add(ds.person(`${EX}carol`))
+        alice.children.add(ds.person(`${EX}dave`))
+
+        assert.deepEqual(snapshots, [
+            [`${EX}bob`],
+            [`${EX}bob`, `${EX}carol`],
+            [`${EX}bob`, `${EX}carol`, `${EX}dave`],
+        ])
+    })
+
+    await it("emits delete events for removals and clear()", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        const bob = ds.person(`${EX}bob`)
+        const carol = ds.person(`${EX}carol`)
+        alice.children.add(bob)
+        alice.children.add(carol)
+
+        const events: string[] = []
+        ds.on((event, quad) => {
+            events.push(`${event}:${quad.object.value}`)
+        })
+
+        alice.children.delete(bob)
+        alice.children.clear()
+
+        assert.deepEqual(events, [
+            `delete:${EX}bob`,
+            `delete:${EX}carol`,
+        ])
+        assert.equal(alice.children.size, 0)
+    })
+
+    await it("emits matching add and delete events with the full quad", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        const bob = ds.person(`${EX}bob`)
+
+        const datasetEvents: string[] = []
+        ds.on((event, q) => {
+            datasetEvents.push(
+                `${event}:${q.subject.value}:${q.predicate.value}:${q.object.value}`,
+            )
+        })
+
+        alice.children.add(bob)
+        alice.children.delete(bob)
+
+        assert.deepEqual(datasetEvents, [
+            `add:${EX}alice:${HAS_CHILD}:${EX}bob`,
+            `delete:${EX}alice:${HAS_CHILD}:${EX}bob`,
+        ])
+    })
+
+    await it("events fire once per item when clear() removes many", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        const bob = ds.person(`${EX}bob`)
+        const carol = ds.person(`${EX}carol`)
+        alice.children.add(bob)
+        alice.children.add(carol)
+
+        const datasetEvents: string[] = []
+        ds.on((event, q) => {
+            if (q.predicate.value !== HAS_CHILD) {
+                return
+            }
+            datasetEvents.push(`${event}:${q.object.value}`)
+        })
+
+        alice.children.clear()
+
+        assert.deepEqual(datasetEvents.sort(), [
+            `delete:${EX}bob`,
+            `delete:${EX}carol`,
+        ])
+    })
+})
+
+await describe("Example: observing an optional email field", async () => {
+    /** Records `set:<value>` and `unset:<value>` notifications for `:hasEmail`. */
+    function watchEmail(ds: People): string[] {
+        const log: string[] = []
+        ds.on((event, q) => {
+            if (q.predicate.value !== HAS_EMAIL) {
+                return
+            }
+            log.push(`${event === "add" ? "set" : "unset"}:${q.object.value}`)
+        })
+        return log
+    }
+
+    await it("setting an email from undefined emits a single set event", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        const log = watchEmail(ds)
+
+        alice.email = "alice@example.org"
+
+        assert.deepEqual(log, ["set:alice@example.org"])
+        assert.equal(alice.email, "alice@example.org")
+    })
+
+    await it("changing an email emits unset (old) then set (new)", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        alice.email = "old@example.org"
+        const log = watchEmail(ds)
+
+        alice.email = "new@example.org"
+
+        assert.deepEqual(log, ["unset:old@example.org", "set:new@example.org"])
+        assert.equal(alice.email, "new@example.org")
+    })
+
+    await it("clearing an email emits only an unset event", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        alice.email = "alice@example.org"
+        const log = watchEmail(ds)
+
+        alice.email = undefined
+
+        assert.deepEqual(log, ["unset:alice@example.org"])
+        assert.equal(alice.email, undefined)
+    })
+
+    await it("clearing an already-empty email emits nothing", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        const log = watchEmail(ds)
+
+        alice.email = undefined
+
+        assert.deepEqual(log, [])
+    })
+
+    await it("emits matching add and delete events with the full quad when changing", () => {
+        const ds = new People(datasetFromRdf(""), DataFactory)
+        const alice = ds.person(`${EX}alice`)
+        alice.email = "old@example.org"
+
+        const datasetEvents: string[] = []
+        ds.on((event, q) => {
+            datasetEvents.push(
+                `${event}:${q.subject.value}:${q.predicate.value}:${q.object.value}`,
+            )
+        })
+
+        alice.email = "new@example.org"
+
+        assert.deepEqual(datasetEvents, [
+            `delete:${EX}alice:${HAS_EMAIL}:old@example.org`,
+            `add:${EX}alice:${HAS_EMAIL}:new@example.org`,
+        ])
+    })
+})


### PR DESCRIPTION
Adds change notifications to `DatasetWrapper`: consumers can now observe every effective mutation of the underlying data with `on(listener)` / `off(listener)`.

## What it does

- `DatasetWrapper` still accepts any RDF/JS `DatasetCore` (constructor signature unchanged) and now internally ensures an eventful layer over it (`ensureEventfulDatasetCore`). The passed dataset remains the single place of storage — mutations write through to it, so external references to it observe all changes.
- New public API: `DatasetWrapper.on(listener)` and `DatasetWrapper.off(listener)`, plus the exported `IDatasetChangeListener` / `ChangeEvent` types. Listeners are called synchronously with `("add" | "delete", quad)`.
- Only **effective** changes notify (per `Quad.equals`): adding an already-contained quad or deleting an absent one emits nothing.
- Because all wrapper-driven mutations flow through `DatasetWrapper.add`/`delete`, events fire uniformly for:
  - direct `add`/`delete` calls,
  - property assignments through `RequiredAs`/`OptionalAs` mappings (delete of the previous quads, then add — assignments do not deduplicate; clearing an optional property emits only deletes),
  - mutations of `Set`s produced by `SetFrom` (`add`/`delete`/`clear`),
  - mutations through named graph views created with `named(...)`, which share the same eventful core.
- Subscribing the same listener twice is a no-op; so is detaching a listener that is not subscribed.

## Dependency

This introduces the package's first runtime dependency: the event-emitting `DatasetCore` lives in [`@jeswr/eventful-dataset`](https://github.com/jeswr/eventful-dataset/tree/feat/eventful-dataset) rather than being copied in-repo. It is currently pinned as a `github:` branch dependency while it is staged; it would move to a released npm version (or wherever the group prefers it to live) before this leaves draft. Flagging it explicitly since `"dependencies": {}` was a visible property of this package.

## Relation to #73

Supersedes the **events slice** of #73 (Omnibus): the `DatasetWrapper.on`/`off` wiring, the `NotificationsDatasetCore` concern, and the dataset events tests. The `EventEmitter`/notifying-dataset implementation now comes from the foundation package instead of the in-repo `src/EventEmitter.ts` + `src/dataset/NotifyingDatasetCore.ts` copies.

Deliberately **not** included from #73 (left to their own slices): the `Triple`/default-graph restriction, the `datasetFactory` constructor parameter, `GraphScopedDataset`/`ProjectedDataset`, and all of the async (`AsyncDatasetCore`) work. No `size`/`match` semantics change here.

## Tests

- `test/unit/dataset_events.test.ts` — direct add/delete notifications, effective-change filtering, listener bookkeeping (off, double-subscribe, multiple listeners), and wrapper-driven events for required/optional/typed properties and Set mappings, on the existing Parent/Child fixtures.
- `test/unit/dataset_events_examples.test.ts` — the JSDoc-style examples as executable tests: observing a `SetFrom`-backed children set (live views, per-item events) and an optional email field.

`npm i && npx tsc && npm test && npx typedoc && npm audit --omit=dev --audit-level=moderate` all pass locally (150 tests, 0 fail; typedoc warnings unchanged from `main`).

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday-Friday (8-10 July).
