### PR TITLE
feat: GraphScopedDataset — read from many graphs, write to one

### DIFF
--- a/src/DatasetWrapper.ts
+++ b/src/DatasetWrapper.ts
@@ -2,6 +2,8 @@ import type { DataFactory, DatasetCore, Quad, Quad_Graph, Term } from "@rdfjs/ty
 import type { ITermWrapperConstructor } from "./type/ITermWrapperConstructor.js"
 import type { NamedGraphDataset } from "./NamedGraphDataset.js"
 import type { INamedGraphDatasetConstructor } from "./type/INamedGraphDatasetConstructor.js"
+import type { GraphScopedDataset } from "./GraphScopedDataset.js"
+import type { IGraphScopedDatasetConstructor } from "./type/IGraphScopedDatasetConstructor.js"
 
 import { RDF } from "./vocabulary/RDF.js"
 
@@ -67,6 +69,22 @@ export class DatasetWrapper implements DatasetCore {
     protected named<T extends NamedGraphDataset>(graph: string | Quad_Graph, klass: INamedGraphDatasetConstructor<T>): T {
         const g = typeof graph === "string" ? this.factory.namedNode(graph) : graph
         return new klass(g, this.dataset, this.factory)
+    }
+
+    /**
+     * Creates a view over a configurable set of graphs in the underlying dataset, projected onto the default graph.
+     *
+     * Reads come from the supplied `readGraphs`; if `readGraphs` is `undefined`, quads from every graph (default and named) are read, and a triple appearing in multiple graphs is exposed only once. Writes through the view are mapped to `writeGraph` in the underlying dataset. Any attempt to use a non-default graph on the returned dataset throws a {@link NamedGraphError} (for write operations) or a {@link TermTypeError} (for {@link DatasetCore.match}).
+     *
+     * @param writeGraph - The graph that writes through the view are directed to.
+     * @param readGraphs - The graphs that are read through the view, or `undefined` to read from every graph.
+     * @param klass - A constructor of a class derived from graph scoped dataset
+     * @returns An instance of a class derived from {@link GraphScopedDataset} that is a view scoped to the specified graphs.
+     */
+    protected scoped<T extends GraphScopedDataset>(writeGraph: string | Quad_Graph, readGraphs: ReadonlyArray<string | Quad_Graph> | undefined, klass: IGraphScopedDatasetConstructor<T>): T {
+        const write = typeof writeGraph === "string" ? this.factory.namedNode(writeGraph) : writeGraph
+        const reads = readGraphs?.map(graph => typeof graph === "string" ? this.factory.namedNode(graph) : graph)
+        return new klass(write, reads, this.dataset, this.factory)
     }
 
     protected* matchSubjectsOf<T>(termWrapper: ITermWrapperConstructor<T>, predicate?: Term, object?: Term, graph?: Term): Iterable<T> {

--- a/src/GraphScopedDataset.ts
+++ b/src/GraphScopedDataset.ts
@@ -1,0 +1,234 @@
+import type { DataFactory, DatasetCore, Quad, Quad_Graph, Term } from "@rdfjs/types"
+import { DatasetWrapper } from "./DatasetWrapper.js"
+import { ensureDefaultGraph, ensureTermType } from "./ensure.js"
+
+/**
+ * A dataset view that reads from a configurable set of graphs and writes to a single graph.
+ *
+ * Quads read through the view are projected onto the default graph: their graph component is replaced by the default graph, and a triple that occurs in more than one read graph is exposed only once. Quads written through the view ({@link add}, {@link delete}) are mapped back to the configured write graph in the underlying dataset.
+ *
+ * @remarks
+ * This class generalizes {@link NamedGraphDataset}, which is the special case of reading from and writing to the same single graph. It addresses the common asymmetry in RDF applications where data is assembled from several graphs (for example, a union over every graph in the dataset) but changes must land in one designated graph.
+ *
+ * Because the projection rewrites every read quad to the default graph, {@link TermWrapper} and {@link DatasetWrapper} subclasses that operate on the default graph work unchanged against quads that live in named graphs.
+ *
+ * The view enforces the default graph on its own surface:
+ * - {@link add}, {@link delete} and {@link has} throw a {@link NamedGraphError} when the supplied quad is not in the default graph.
+ * - {@link match} throws a {@link TermTypeError} when the graph argument is present and not the default graph.
+ *
+ * @example Reading a union of all graphs while writing to one graph
+ * Assume the following RDF data:
+ * ```turtle
+ * BASE <https://example.org/>
+ * PREFIX : <https://example.org/>
+ *
+ * <x> :hasString "from the default graph" .
+ *
+ * :g1 { <x> :hasString "from g1" . }
+ * :g2 { <x> :hasString "from g2" . }
+ * ```
+ *
+ * A read scope of `undefined` reads every graph; writes are directed to one graph:
+ * ```ts
+ * class SomeDataset extends DatasetWrapper {
+ *     get union(): GraphScopedDataset {
+ *         return this.scoped("https://example.org/g1", undefined, GraphScopedDataset)
+ *     }
+ * }
+ *
+ * const union = new SomeDataset(dataset, factory).union
+ *
+ * union.size // 3 — one triple per distinct value, all projected onto the default graph
+ * union.add(quad) // written to <https://example.org/g1> in the underlying dataset
+ * ```
+ *
+ * @example Reading selected graphs
+ * Passing an explicit read scope restricts reads to those graphs:
+ * ```ts
+ * class SomeDataset extends DatasetWrapper {
+ *     get merged(): GraphScopedDataset {
+ *         return this.scoped("https://example.org/g1", ["https://example.org/g1", "https://example.org/g2"], GraphScopedDataset)
+ *     }
+ * }
+ *
+ * const merged = new SomeDataset(dataset, factory).merged
+ *
+ * merged.size // 2 — the default-graph triple is out of scope
+ * ```
+ *
+ * @example Reusing term wrappers over named-graph data
+ * Subclasses extend this class the same way they extend {@link DatasetWrapper}:
+ * ```ts
+ * class People extends GraphScopedDataset {
+ *     get all(): Iterable<Person> {
+ *         return this.subjectsOf("https://example.org/hasName", Person)
+ *     }
+ * }
+ *
+ * class Workspace extends DatasetWrapper {
+ *     people(graph: string): People {
+ *         return this.scoped(graph, undefined, People)
+ *     }
+ * }
+ * ```
+ *
+ * @see {@link DatasetWrapper.scoped} — the recommended way to obtain instances.
+ * @see {@link NamedGraphDataset} — the single-graph special case.
+ * @see [RDF/JS Dataset specification](https://rdf.js.org/dataset-spec/) — the contract implemented by this view.
+ */
+export class GraphScopedDataset extends DatasetWrapper {
+    //#region DatasetCore
+
+    /**
+     * Creates a new instance of {@link GraphScopedDataset}.
+     *
+     * Application code typically does not call this constructor directly but obtains instances through {@link DatasetWrapper.scoped}, which resolves graph IRIs and forwards the underlying dataset and factory.
+     *
+     * @param writeGraph The graph in the underlying dataset that writes through this view are directed to.
+     * @param readGraphs The graphs read through this view. If `undefined`, every graph in the underlying dataset is read (a deduplicated union).
+     * @param dataset The underlying dataset to project.
+     * @param factory A collection of methods for creating the rewritten quads.
+     */
+    public constructor(
+        private readonly writeGraph: Quad_Graph,
+        private readonly readGraphs: ReadonlyArray<Quad_Graph> | undefined,
+        dataset: DatasetCore,
+        factory: DataFactory,
+    ) {
+        super(dataset, factory)
+    }
+
+    /**
+     * The number of distinct triples visible through the read scope.
+     */
+    public override get size(): number {
+        let size = 0
+
+        for (const _ of this) {
+            size += 1
+        }
+
+        return size
+    }
+
+    /**
+     * Iterates the triples in the read scope, projected onto the default graph. A triple occurring in more than one read graph is yielded only once.
+     */
+    public override* [Symbol.iterator](): Iterator<Quad> {
+        const seen = new Set<string>()
+
+        for (const quad of this.readScope()) {
+            const key = GraphScopedDataset.keyOf(quad)
+
+            if (!seen.has(key)) {
+                seen.add(key)
+                yield this.asDefault(quad)
+            }
+        }
+    }
+
+    /**
+     * Adds `quad` to the underlying dataset, rewriting its graph to the write graph.
+     *
+     * @throws A {@link NamedGraphError} when `quad` is not in the default graph.
+     */
+    public override add(quad: Quad): this {
+        ensureDefaultGraph(quad)
+        super.add(this.inGraph(quad, this.writeGraph))
+        return this
+    }
+
+    /**
+     * Removes `quad` from the write graph of the underlying dataset. Copies of the same triple in other graphs are left untouched.
+     *
+     * @throws A {@link NamedGraphError} when `quad` is not in the default graph.
+     */
+    public override delete(quad: Quad): this {
+        ensureDefaultGraph(quad)
+        super.delete(this.inGraph(quad, this.writeGraph))
+        return this
+    }
+
+    /**
+     * Returns whether any graph in the read scope contains `quad`.
+     *
+     * @throws A {@link NamedGraphError} when `quad` is not in the default graph.
+     */
+    public override has(quad: Quad): boolean {
+        ensureDefaultGraph(quad)
+
+        if (this.readGraphs === undefined) {
+            return super.match(quad.subject, quad.predicate, quad.object).size > 0
+        }
+
+        return this.readGraphs.some(graph => super.has(this.inGraph(quad, graph)))
+    }
+
+    /**
+     * Returns a {@link GraphScopedDataset} with the matching triples of the read scope, projected onto the default graph.
+     *
+     * @throws A {@link TermTypeError} when `graph` is present and not the default graph.
+     */
+    public override match(subject?: Term, predicate?: Term, object?: Term, graph?: Term): DatasetCore {
+        if (graph !== undefined) {
+            ensureTermType(graph, "DefaultGraph")
+        }
+
+        return new GraphScopedDataset(this.writeGraph, this.readGraphs, super.match(subject, predicate, object), this.factory)
+    }
+
+    //#endregion
+
+    //#region Utilities
+
+    /**
+     * Yields the quads of the underlying dataset that are within the read scope, in their original graphs.
+     */
+    private* readScope(): Iterable<Quad> {
+        if (this.readGraphs === undefined) {
+            yield* super.match()
+            return
+        }
+
+        for (const graph of this.readGraphs) {
+            yield* super.match(undefined, undefined, undefined, graph)
+        }
+    }
+
+    /**
+     * Returns a copy of `quad` placed in `graph`.
+     */
+    private inGraph(quad: Quad, graph: Quad_Graph): Quad {
+        return this.factory.quad(quad.subject, quad.predicate, quad.object, graph)
+    }
+
+    /**
+     * Returns a copy of `quad` placed in the default graph.
+     */
+    private asDefault(quad: Quad): Quad {
+        return this.factory.quad(quad.subject, quad.predicate, quad.object)
+    }
+
+    /**
+     * Derives a string key that identifies the triple components of `quad` (its graph is ignored), so that quads whose subjects, predicates and objects are equal per [Term.equals](https://rdf.js.org/data-model-spec/#dfn-equals) map to the same key.
+     */
+    private static keyOf(quad: Quad): string {
+        return `${GraphScopedDataset.termKey(quad.subject)} ${GraphScopedDataset.termKey(quad.predicate)} ${GraphScopedDataset.termKey(quad.object)}`
+    }
+
+    /**
+     * Derives a string key that identifies a term by value, so that terms equal per [Term.equals](https://rdf.js.org/data-model-spec/#dfn-equals) map to the same key.
+     */
+    private static termKey(term: Term): string {
+        switch (term.termType) {
+            case "Literal":
+                return `${term.termType} ${term.language} ${term.direction ?? ""} ${JSON.stringify(term.datatype.value)} ${JSON.stringify(term.value)}`
+            case "Quad":
+                return `${term.termType} ${GraphScopedDataset.termKey(term.subject)} ${GraphScopedDataset.termKey(term.predicate)} ${GraphScopedDataset.termKey(term.object)} ${GraphScopedDataset.termKey(term.graph)}`
+            default:
+                return `${term.termType} ${JSON.stringify(term.value)}`
+        }
+    }
+
+    //#endregion
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,6 +1,7 @@
 export type * from "./type/ITermAsValueMapping.js"
 export type * from "./type/ITermWrapperConstructor.js"
 export type * from "./type/INamedGraphDatasetConstructor.js"
+export type * from "./type/IGraphScopedDatasetConstructor.js"
 export type * from "./type/ITermFromValueMapping.js"
 export type * from "./type/ILangString.js"
 
@@ -21,6 +22,7 @@ export * from "./mapping/RequiredAs.js"
 export * from "./DatasetWrapper.js"
 export * from "./TermWrapper.js"
 export * from "./NamedGraphDataset.js"
+export * from "./GraphScopedDataset.js"
 
 export * from "./errors/WrapperError.js"
 export * from "./errors/TermError.js"

--- a/src/type/IGraphScopedDatasetConstructor.ts
+++ b/src/type/IGraphScopedDatasetConstructor.ts
@@ -1,0 +1,7 @@
+import type { DataFactory, DatasetCore, Quad_Graph } from "@rdfjs/types"
+import type { GraphScopedDataset } from "../GraphScopedDataset.js"
+
+/**
+ * Constructor signature for any subclass of {@link GraphScopedDataset}, as accepted by {@link DatasetWrapper.scoped}.
+ */
+export type IGraphScopedDatasetConstructor<T extends GraphScopedDataset> = new (writeGraph: Quad_Graph, readGraphs: ReadonlyArray<Quad_Graph> | undefined, dataset: DatasetCore, factory: DataFactory) => T

--- a/test/unit/graph_scoped.test.ts
+++ b/test/unit/graph_scoped.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert"
+import { describe, it } from "node:test"
+import { DataFactory, Store } from "n3"
+import { DatasetWrapper, GraphScopedDataset, NamedGraphError, TermTypeError } from "@rdfjs/wrapper"
+
+const g1 = DataFactory.namedNode("https://example.org/g1")
+const g2 = DataFactory.namedNode("https://example.org/g2")
+const g3 = DataFactory.namedNode("https://example.org/g3")
+const s = DataFactory.namedNode("https://example.org/s")
+const p = DataFactory.namedNode("https://example.org/p")
+const p2 = DataFactory.namedNode("https://example.org/p2")
+const o1 = DataFactory.literal("o1")
+const o2 = DataFactory.literal("o2")
+const o3 = DataFactory.literal("o3")
+const oDefault = DataFactory.literal("default")
+
+function multiGraphStore(): Store {
+    const store = new Store()
+    store.addQuad(DataFactory.quad(s, p, oDefault))
+    store.addQuad(DataFactory.quad(s, p, o1, g1))
+    store.addQuad(DataFactory.quad(s, p, o2, g2))
+    store.addQuad(DataFactory.quad(s, p, o3, g3))
+    return store
+}
+
+class SomeDataset extends DatasetWrapper {
+    get scopedView(): GraphScopedDataset {
+        return this.scoped(g1, ["https://example.org/g1", g2], GraphScopedDataset)
+    }
+
+    get unionView(): GraphScopedDataset {
+        return this.scoped(g1, undefined, GraphScopedDataset)
+    }
+}
+
+await describe("GraphScopedDataset (explicit read graphs)", async () => {
+    await it("iterates only quads in the configured read graphs projected to the default graph", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).scopedView
+        const quads = Array.from(view)
+
+        assert.deepEqual(quads.map(quad => quad.object.value).sort(), ["o1", "o2"])
+        for (const quad of quads) {
+            assert.equal(quad.graph.termType, "DefaultGraph")
+        }
+    })
+
+    await it("deduplicates triples that appear in multiple read graphs", () => {
+        const store = new Store()
+        store.addQuad(DataFactory.quad(s, p, o1, g1))
+        store.addQuad(DataFactory.quad(s, p, o1, g2))
+
+        const view = new SomeDataset(store, DataFactory).scopedView
+
+        assert.equal(view.size, 1)
+        assert.equal(Array.from(view).length, 1)
+    })
+
+    await it("keeps literals that differ only in language or datatype", () => {
+        const store = new Store()
+        store.addQuad(DataFactory.quad(s, p, DataFactory.literal("chat", "en"), g1))
+        store.addQuad(DataFactory.quad(s, p, DataFactory.literal("chat", "fr"), g2))
+
+        const view = new SomeDataset(store, DataFactory).scopedView
+
+        assert.equal(view.size, 2)
+    })
+
+    await it("deduplicates triples whose subject is a quoted triple", () => {
+        const quoted = DataFactory.quad(s, p, o1)
+        const store = new Store()
+        store.addQuad(DataFactory.quad(quoted, p, o2, g1))
+        store.addQuad(DataFactory.quad(quoted, p, o2, g2))
+
+        const view = new SomeDataset(store, DataFactory).scopedView
+
+        assert.equal(view.size, 1)
+    })
+
+    await it("size reflects distinct triples across the read graphs", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).scopedView
+
+        assert.equal(view.size, 2)
+    })
+
+    await it("has finds triples in any read graph", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).scopedView
+
+        assert.equal(view.has(DataFactory.quad(s, p, o1)), true)
+        assert.equal(view.has(DataFactory.quad(s, p, o2)), true)
+        assert.equal(view.has(DataFactory.quad(s, p, o3)), false)
+        assert.equal(view.has(DataFactory.quad(s, p, oDefault)), false)
+    })
+
+    await it("add rewrites the graph to the configured write graph", () => {
+        const store = multiGraphStore()
+        const view = new SomeDataset(store, DataFactory).scopedView
+        const newObject = DataFactory.literal("added")
+
+        view.add(DataFactory.quad(s, p, newObject))
+
+        assert.equal(store.has(DataFactory.quad(s, p, newObject, g1)), true)
+        assert.equal(store.has(DataFactory.quad(s, p, newObject)), false)
+        assert.equal(store.has(DataFactory.quad(s, p, newObject, g2)), false)
+    })
+
+    await it("delete only removes from the configured write graph", () => {
+        const store = multiGraphStore()
+        const view = new SomeDataset(store, DataFactory).scopedView
+
+        // The triple <s,p,"o1"> exists in the write graph so it should be removed.
+        view.delete(DataFactory.quad(s, p, o1))
+        assert.equal(store.has(DataFactory.quad(s, p, o1, g1)), false)
+
+        // The triple <s,p,"o2"> exists in another read graph and is left untouched.
+        view.delete(DataFactory.quad(s, p, o2))
+        assert.equal(store.has(DataFactory.quad(s, p, o2, g2)), true)
+    })
+
+    await it("match filters by subject/predicate/object across the read graphs", () => {
+        const store = multiGraphStore()
+        store.addQuad(DataFactory.quad(s, p2, DataFactory.literal("other"), g2))
+        store.addQuad(DataFactory.quad(s, p2, DataFactory.literal("ignored"), g3))
+
+        const view = new SomeDataset(store, DataFactory).scopedView
+        const matched = Array.from(view.match(undefined, p2))
+
+        assert.equal(matched.length, 1)
+        assert.equal(matched[0]!.object.value, "other")
+        assert.equal(matched[0]!.graph.termType, "DefaultGraph")
+    })
+
+    await it("match accepts an explicit DefaultGraph argument", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).scopedView
+        const matched = Array.from(view.match(undefined, undefined, undefined, DataFactory.defaultGraph()))
+
+        assert.equal(matched.length, 2)
+    })
+
+    await it("throws NamedGraphError when adding a quad with a named graph", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).scopedView
+
+        assert.throws(() => view.add(DataFactory.quad(s, p, o1, g3)), NamedGraphError)
+    })
+
+    await it("throws NamedGraphError when deleting a quad with a named graph", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).scopedView
+
+        assert.throws(() => view.delete(DataFactory.quad(s, p, o1, g3)), NamedGraphError)
+    })
+
+    await it("throws NamedGraphError when checking has with a named graph quad", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).scopedView
+
+        assert.throws(() => view.has(DataFactory.quad(s, p, o1, g3)), NamedGraphError)
+    })
+
+    await it("throws TermTypeError when matching with a non-default graph", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).scopedView
+
+        assert.throws(() => view.match(undefined, undefined, undefined, g3), TermTypeError)
+    })
+})
+
+await describe("GraphScopedDataset (union)", async () => {
+    await it("iterates quads from all graphs projected to the default graph", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).unionView
+        const quads = Array.from(view)
+
+        assert.deepEqual(quads.map(quad => quad.object.value).sort(), ["default", "o1", "o2", "o3"])
+        for (const quad of quads) {
+            assert.equal(quad.graph.termType, "DefaultGraph")
+        }
+    })
+
+    await it("deduplicates triples that appear in multiple graphs", () => {
+        const store = new Store()
+        store.addQuad(DataFactory.quad(s, p, o1))
+        store.addQuad(DataFactory.quad(s, p, o1, g1))
+        store.addQuad(DataFactory.quad(s, p, o1, g2))
+
+        const view = new SomeDataset(store, DataFactory).unionView
+
+        assert.equal(view.size, 1)
+        assert.equal(Array.from(view).length, 1)
+    })
+
+    await it("size reflects unique triples across all graphs", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).unionView
+
+        assert.equal(view.size, 4)
+    })
+
+    await it("has finds triples regardless of source graph", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).unionView
+
+        assert.equal(view.has(DataFactory.quad(s, p, oDefault)), true)
+        assert.equal(view.has(DataFactory.quad(s, p, o1)), true)
+        assert.equal(view.has(DataFactory.quad(s, p, o3)), true)
+        assert.equal(view.has(DataFactory.quad(s, p, DataFactory.literal("missing"))), false)
+    })
+
+    await it("match returns a union view filtered by subject/predicate/object", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).unionView
+        const matched = Array.from(view.match(s, p))
+
+        assert.equal(matched.length, 4)
+        for (const quad of matched) {
+            assert.equal(quad.graph.termType, "DefaultGraph")
+        }
+    })
+
+    await it("match accepts an explicit DefaultGraph argument", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).unionView
+        const matched = Array.from(view.match(undefined, undefined, undefined, DataFactory.defaultGraph()))
+
+        assert.equal(matched.length, 4)
+    })
+
+    await it("add inserts into the configured write graph", () => {
+        const store = multiGraphStore()
+        const view = new SomeDataset(store, DataFactory).unionView
+        const newObject = DataFactory.literal("added")
+
+        view.add(DataFactory.quad(s, p, newObject))
+
+        assert.equal(store.has(DataFactory.quad(s, p, newObject, g1)), true)
+        assert.equal(store.has(DataFactory.quad(s, p, newObject)), false)
+    })
+
+    await it("delete only removes from the configured write graph", () => {
+        const store = multiGraphStore()
+        const view = new SomeDataset(store, DataFactory).unionView
+
+        // The triple <s,p,"o1"> exists in the write graph so it should be removed.
+        view.delete(DataFactory.quad(s, p, o1))
+        assert.equal(store.has(DataFactory.quad(s, p, o1, g1)), false)
+
+        // The triple <s,p,"default"> exists in the default graph and is left untouched.
+        view.delete(DataFactory.quad(s, p, oDefault))
+        assert.equal(store.has(DataFactory.quad(s, p, oDefault)), true)
+
+        // The triple <s,p,"o3"> exists in another named graph and is left untouched.
+        view.delete(DataFactory.quad(s, p, o3))
+        assert.equal(store.has(DataFactory.quad(s, p, o3, g3)), true)
+    })
+
+    await it("throws NamedGraphError when adding a quad with a named graph", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).unionView
+
+        assert.throws(() => view.add(DataFactory.quad(s, p, o1, g3)), NamedGraphError)
+    })
+
+    await it("throws TermTypeError when matching with a non-default graph", () => {
+        const view = new SomeDataset(multiGraphStore(), DataFactory).unionView
+
+        assert.throws(() => view.match(undefined, undefined, undefined, g3), TermTypeError)
+    })
+})

--- a/test/unit/graph_scoped_integration.test.ts
+++ b/test/unit/graph_scoped_integration.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert"
+import { describe, it } from "node:test"
+import { DataFactory } from "n3"
+import { Parent } from "./model/Parent.js"
+import { Example } from "./vocabulary/Example.js"
+import { DatasetWrapper, GraphScopedDataset } from "@rdfjs/wrapper"
+import { datasetFromRdf } from "./util/datasetFromRdf.js"
+
+const rdf = `
+PREFIX : <https://example.org/>
+
+<x> :hasString "default value" .
+
+:graph {
+    <x> :hasNullableString "from named" .
+}
+`;
+
+const subject = DataFactory.namedNode("x")
+
+class SomeUnionDataset extends GraphScopedDataset {
+    get parent(): Parent {
+        return new Parent(subject, this, this.factory)
+    }
+
+    get subjectsOfHasNullableString(): Iterable<Parent> {
+        return this.subjectsOf(Example.hasNullableString, Parent)
+    }
+}
+
+class Root extends DatasetWrapper {
+    get union(): SomeUnionDataset {
+        return this.scoped("https://example.org/graph", undefined, SomeUnionDataset)
+    }
+}
+
+await describe("GraphScopedDataset with TermWrapper", async () => {
+    await it("reads properties from any graph through TermWrapper", () => {
+        const parent = new Root(datasetFromRdf(rdf), DataFactory).union.parent
+
+        assert.equal(parent.hasString, "default value")
+        assert.equal(parent.hasNullableString, "from named")
+    })
+
+    await it("finds subjects whose quads live in a named graph", () => {
+        const union = new Root(datasetFromRdf(rdf), DataFactory).union
+        const parents = Array.from(union.subjectsOfHasNullableString)
+
+        assert.equal(parents.length, 1)
+        assert.equal(parents[0]!.hasString, "default value")
+    })
+
+    await it("writes new properties into the configured write graph", () => {
+        const store = datasetFromRdf(rdf)
+        const root = new Root(store, DataFactory)
+
+        root.union.parent.hasNullableString = "updated"
+
+        // The new value is readable through the union view.
+        assert.equal(root.union.parent.hasNullableString, "updated")
+        // The replacement quad lives in the configured write graph.
+        assert.equal(store.has(DataFactory.quad(
+            subject,
+            DataFactory.namedNode(Example.hasNullableString),
+            DataFactory.literal("updated"),
+            DataFactory.namedNode("https://example.org/graph"),
+        )), true)
+        // The original default-graph quad is unaffected.
+        assert.equal(store.has(DataFactory.quad(
+            subject,
+            DataFactory.namedNode(Example.hasString),
+            DataFactory.literal("default value"),
+        )), true)
+    })
+
+    await it("clears optional properties through the union view", () => {
+        const store = datasetFromRdf(rdf)
+        const root = new Root(store, DataFactory)
+
+        root.union.parent.hasNullableString = undefined
+
+        assert.equal(root.union.parent.hasNullableString, undefined)
+        assert.equal(store.has(DataFactory.quad(
+            subject,
+            DataFactory.namedNode(Example.hasNullableString),
+            DataFactory.literal("from named"),
+            DataFactory.namedNode("https://example.org/graph"),
+        )), false)
+    })
+})


### PR DESCRIPTION
### What this does

Adds `GraphScopedDataset`: a dataset view that **reads from a configurable set of graphs and writes to a single graph**, generalizing `NamedGraphDataset` (which is the special case of reading from and writing to the same one graph, and stays untouched for back-compat).

- **Reads** union the configured `readGraphs`, projected onto the default graph, with per-triple deduplication (a triple appearing in several read graphs is exposed once). `readGraphs === undefined` reads *every* graph — a deduplicated union view.
- **Writes** (`add` / `delete`) are rewritten into the configured `writeGraph`; `delete` leaves copies of the triple in other graphs untouched. Non-default-graph input quads throw `NamedGraphError` (via the existing `ensureDefaultGraph`).
- **`has`** answers from the read scope, consistent with iteration.
- **`match(s, p, o[, defaultGraph])`** mirrors `NamedGraphDataset`'s self-wrapping pattern and throws `TermTypeError` for non-default graph arguments.
- `DatasetWrapper` gains a `protected scoped(writeGraph, readGraphs, klass)` helper beside `named()`, accepting IRIs or terms; `IGraphScopedDatasetConstructor` is added to `src/type/`. Both new symbols are exported from `mod.ts`.

Because the projection rewrites every read quad to the default graph, existing `TermWrapper`/`DatasetWrapper` models work unchanged against quads that live in named graphs — including the common read-many/write-one asymmetry (e.g. read the union of a document's graphs, write changes to one designated graph).

### Why

Addresses the graph-scoping follow-up from #43 (@jaxoncreed): LDO-style control over *which graph writes land in*, independent of *which graphs are read*.

### Relation to #73

Supersedes the `GraphScopedDataset` read-write graph-scoping slice of the #73 omnibus, including its `union_graph` / `projected_dataset` read-write test slices. It deliberately excludes the rest of that omnibus: no events plumbing (`NotifyingDatasetCore`), no `LazyMaterialize`, and no breaking default-graph-only `DatasetWrapper` rework — this is a purely additive change.

### Notes

- Triple deduplication keys terms by `termType`/`value` (plus language/direction/datatype for literals, recursion for quoted triples), the same keying used in #88; if both land, the helper can be shared in a follow-up.
- Tests: `test/unit/graph_scoped.test.ts` (explicit read scope + union view) and `test/unit/graph_scoped_integration.test.ts` (`TermWrapper` models reading across graphs and writing into the scoped graph). New code is at 100% line coverage; `npm test` and `npx typedoc` are green.

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday-Friday (8-10 July).
